### PR TITLE
Refactor Storybook configuration to use new API

### DIFF
--- a/apps/extension/.storybook/main.ts
+++ b/apps/extension/.storybook/main.ts
@@ -1,7 +1,7 @@
 import tailwindcss from "@tailwindcss/vite";
-import type { StorybookConfig } from "@storybook/react-vite";
+import { defineMain } from "@storybook/react-vite/node";
 
-const config: StorybookConfig = {
+export default defineMain({
   stories: ["../src/**/*.stories.{ts,tsx}"],
   addons: [],
   framework: {
@@ -12,6 +12,4 @@ const config: StorybookConfig = {
     ...config,
     plugins: [...(config.plugins ?? []), tailwindcss()],
   }),
-};
-
-export default config;
+});

--- a/apps/extension/.storybook/preview.ts
+++ b/apps/extension/.storybook/preview.ts
@@ -1,9 +1,9 @@
-import type { Preview } from "@storybook/react";
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+import { definePreview } from "@storybook/react-vite";
 // @ts-expect-error -- CSS import is handled by Vite; TS doesn't know the module
 import "../src/assets/global.css";
 
-const preview: Preview = {
+export default definePreview({
+  addons: [],
   parameters: {
     controls: {
       matchers: {
@@ -13,6 +13,4 @@ const preview: Preview = {
     },
     layout: "padded",
   },
-};
-
-export default preview;
+});

--- a/apps/extension/src/components/ServerLogin.stories.tsx
+++ b/apps/extension/src/components/ServerLogin.stories.tsx
@@ -1,7 +1,7 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import preview from "../../.storybook/preview";
 import ServerLogin from "./ServerLogin.tsx";
 
-const meta = {
+const meta = preview.meta({
   title: "Components/ServerLogin",
   component: ServerLogin,
   args: {
@@ -9,31 +9,30 @@ const meta = {
     onLogout: () => {},
     onRefresh: () => {},
   },
-} satisfies Meta<typeof ServerLogin>;
+});
 
 export default meta;
-type Story = StoryObj<typeof meta>;
 
-export const NotLoggedIn: Story = {
+export const NotLoggedIn = meta.story({
   args: {
     isAuthenticated: false,
     user: null,
     isLoading: false,
   },
-};
+});
 
-export const LoggedIn: Story = {
+export const LoggedIn = meta.story({
   args: {
     isAuthenticated: true,
     user: { email: "user@example.com", sub: "auth0|abc123" },
     isLoading: false,
   },
-};
+});
 
-export const ServerLoadingState: Story = {
+export const ServerLoadingState = meta.story({
   args: {
     isAuthenticated: false,
     user: null,
     isLoading: true,
   },
-};
+});

--- a/apps/extension/src/components/ZaimLogin.stories.tsx
+++ b/apps/extension/src/components/ZaimLogin.stories.tsx
@@ -1,7 +1,7 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import preview from "../../.storybook/preview";
 import ZaimLogin from "./ZaimLogin.tsx";
 
-const meta = {
+const meta = preview.meta({
   title: "Components/ZaimLogin",
   component: ZaimLogin,
   args: {
@@ -9,31 +9,30 @@ const meta = {
     onDisconnect: () => {},
     onRefresh: () => {},
   },
-} satisfies Meta<typeof ZaimLogin>;
+});
 
 export default meta;
-type Story = StoryObj<typeof meta>;
 
-export const NotConnected: Story = {
+export const NotConnected = meta.story({
   args: {
     isConnected: false,
     zaimUserId: null,
     isLoading: false,
   },
-};
+});
 
-export const Connected: Story = {
+export const Connected = meta.story({
   args: {
     isConnected: true,
     zaimUserId: "zaim_user_123456",
     isLoading: false,
   },
-};
+});
 
-export const ZaimLoadingState: Story = {
+export const ZaimLoadingState = meta.story({
   args: {
     isConnected: false,
     zaimUserId: null,
     isLoading: true,
   },
-};
+});


### PR DESCRIPTION
## Summary
Updated Storybook configuration and story files to use the new `@storybook/react-vite` API with `definePreview` and `defineMain` functions, along with a custom preview helper for story definitions.

## Key Changes
- **Preview configuration** (`preview.ts`): Migrated from `Preview` type to `definePreview()` function from `@storybook/react-vite`
- **Main configuration** (`main.ts`): Migrated from `StorybookConfig` type to `defineMain()` function from `@storybook/react-vite/node`
- **Story files** (`ServerLogin.stories.tsx`, `ZaimLogin.stories.tsx`): 
  - Removed direct imports of `Meta` and `StoryObj` types from `@storybook/react`
  - Replaced with custom `preview.meta()` and `preview.story()` helper functions
  - Simplified story definitions by removing explicit type annotations
  - Changed from object literals with `satisfies` keyword to function-based API

## Implementation Details
- The new API uses builder functions (`definePreview`, `defineMain`, `meta()`, `story()`) instead of type-annotated object literals
- This approach provides better type safety and consistency across the Storybook configuration
- The custom preview helpers abstract away the Storybook types, making story files cleaner and more maintainable
- All configuration remains functionally equivalent to the previous implementation

https://claude.ai/code/session_01U8VVJgRTWgU6JvfW8dCAX8