### PR TITLE
Refactor route definitions to use method chaining pattern

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -15,8 +15,10 @@
   "dependencies": {
     "@cloudflare/kumo": "^1.19.0",
     "@phosphor-icons/react": "^2.1.10",
+    "hono": "^4.12.14",
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "server": "workspace:*"
   },
   "devDependencies": {
     "@storybook/react": "^10.3.5",

--- a/apps/extension/src/entrypoints/sidepanel/App.tsx
+++ b/apps/extension/src/entrypoints/sidepanel/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { createClient } from "server/client";
 import ServerLogin from "../../components/ServerLogin.tsx";
 import ZaimLogin from "../../components/ZaimLogin.tsx";
 
@@ -34,13 +35,12 @@ export default function App() {
     if (!url) return;
     setAuth((prev) => ({ ...prev, isLoading: true, error: null }));
 
+    const client = createClient(url);
+
     let meRes: Response;
     try {
       // redirect: "manual" でOIDCリダイレクト(302)をエラーなく検知する
-      meRes = await fetch(`${url}/me`, {
-        credentials: "include",
-        redirect: "manual",
-      });
+      meRes = await client.me.$get({}, { init: { credentials: "include", redirect: "manual" } });
     } catch {
       // ネットワークエラー（サーバー未起動・URLが不正など）
       setAuth({
@@ -58,22 +58,22 @@ export default function App() {
     }
 
     try {
-      const user: ServerUser = await meRes.json();
+      const user = await meRes.json();
 
-      const zaimRes = await fetch(`${url}/zaim/auth/status`, {
-        credentials: "include",
-        redirect: "manual",
-      });
+      const zaimRes = await client.zaim.auth.status.$get(
+        {},
+        { init: { credentials: "include", redirect: "manual" } },
+      );
       const zaim =
         zaimRes.ok && zaimRes.type !== "opaqueredirect"
           ? await zaimRes.json()
-          : { connected: false, zaimUserId: null };
+          : { connected: false as const };
 
       setAuth({
         isServerAuthenticated: true,
         serverUser: user,
-        isZaimConnected: zaim.connected ?? false,
-        zaimUserId: zaim.zaimUserId ?? null,
+        isZaimConnected: zaim.connected,
+        zaimUserId: "zaimUserId" in zaim ? zaim.zaimUserId : null,
         isLoading: false,
         error: null,
       });
@@ -115,11 +115,9 @@ export default function App() {
 
   async function handleZaimDisconnect() {
     setAuth((prev) => ({ ...prev, isLoading: true }));
+    const client = createClient(serverUrl);
     try {
-      await fetch(`${serverUrl}/zaim/auth/token`, {
-        method: "DELETE",
-        credentials: "include",
-      });
+      await client.zaim.auth.token.$delete({}, { init: { credentials: "include" } });
       setAuth((prev) => ({
         ...prev,
         isZaimConnected: false,

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./client": "./src/client.ts"
+  },
   "scripts": {
     "dev": "wrangler dev",
     "build": "wrangler deploy --dry-run --outdir dist",

--- a/apps/server/src/client.ts
+++ b/apps/server/src/client.ts
@@ -1,0 +1,7 @@
+import { hc } from "hono/client";
+import type { AppType } from "./index.ts";
+
+export const createClient = (baseUrl: string, options?: Parameters<typeof hc>[1]) =>
+  hc<AppType>(baseUrl, options);
+
+export type { AppType };

--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -1,3 +1,5 @@
+import type { KVNamespace } from "@cloudflare/workers-types";
+
 /**
  * Cloudflare Workers の環境変数（バインディング）の型定義
  */

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -7,12 +7,12 @@ import "./logger.ts";
 import { authRoutes } from "./routes/auth.ts";
 import { zaimRoutes } from "./routes/zaim.ts";
 
-const app = new Hono<{ Bindings: Env }>();
+const base = new Hono<{ Bindings: Env }>();
 
-app.use(honoLogger({ category: ["quick-zaim", "server"] }));
+base.use(honoLogger({ category: ["quick-zaim", "server"] }));
 
 // Chrome拡張機能・ローカル開発からのクロスオリジンリクエストを許可
-app.use(
+base.use(
   cors({
     origin: (origin) => {
       if (!origin) return null;
@@ -31,29 +31,29 @@ app.use(
   }),
 );
 
-// 公開ルート（認証不要）
-app.get("/", (c) => c.text("Hello World!"));
-
 // 認証ミドルウェアをルートハンドラより前に登録する（Honoは登録順にマッチするため）
 // /callback は oidcAuthMiddleware() 内部で OIDC_REDIRECT_URI と照合して自動処理する
-app.use("/callback", oidcAuthMiddleware());
-app.use("/me", oidcAuthMiddleware());
-app.use("/api/*", oidcAuthMiddleware());
+base.use("/callback", oidcAuthMiddleware());
+base.use("/me", oidcAuthMiddleware());
+base.use("/api/*", oidcAuthMiddleware());
 
 // Zaim OAuth ルート
 // /zaim/auth/start, /zaim/auth/status, /zaim/auth/token は OIDC 認証が必要
 // /zaim/auth/callback は Zaim からのリダイレクトを受け取るため OIDC 不要
 //   （ユーザー識別は KV に保存した OIDC sub で行う）
-app.use("/zaim/auth/start", oidcAuthMiddleware());
-app.use("/zaim/auth/status", oidcAuthMiddleware());
-app.use("/zaim/auth/token", oidcAuthMiddleware());
+base.use("/zaim/auth/start", oidcAuthMiddleware());
+base.use("/zaim/auth/status", oidcAuthMiddleware());
+base.use("/zaim/auth/token", oidcAuthMiddleware());
 
-// 認証関連ルート（/logout, /me）
-app.route("/", authRoutes);
-
-// Zaim OAuth フロー（/zaim/auth/*）
-app.route("/", zaimRoutes);
-
-app.get("/api/health", (c) => c.json({ status: "ok" }));
+// ルートをチェーンして AppType に正確なスキーマ型を持たせる
+const app = base
+  // 公開ルート（認証不要）
+  .get("/", (c) => c.text("Hello World!"))
+  // 認証関連ルート（/logout, /me）
+  .route("/", authRoutes)
+  // Zaim OAuth フロー（/zaim/auth/*）
+  .route("/", zaimRoutes)
+  .get("/api/health", (c) => c.json({ status: "ok" }));
 
 export default app;
+export type AppType = typeof app;

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -45,15 +45,20 @@ base.use("/zaim/auth/start", oidcAuthMiddleware());
 base.use("/zaim/auth/status", oidcAuthMiddleware());
 base.use("/zaim/auth/token", oidcAuthMiddleware());
 
-// ルートをチェーンして AppType に正確なスキーマ型を持たせる
+// 公開ルート（認証不要）
+const rootRoute = new Hono<{ Bindings: Env }>().get("/", (c) => c.text("Hello World!"));
+const healthRoute = new Hono<{ Bindings: Env }>().get("/api/health", (c) =>
+  c.json({ status: "ok" }),
+);
+
+// ルートを集約して AppType に正確なスキーマ型を持たせる
 const app = base
-  // 公開ルート（認証不要）
-  .get("/", (c) => c.text("Hello World!"))
+  .route("/", rootRoute)
   // 認証関連ルート（/logout, /me）
   .route("/", authRoutes)
   // Zaim OAuth フロー（/zaim/auth/*）
   .route("/", zaimRoutes)
-  .get("/api/health", (c) => c.json({ status: "ok" }));
+  .route("/", healthRoute);
 
 export default app;
 export type AppType = typeof app;

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -3,40 +3,38 @@ import { Hono } from "hono";
 import type { Env } from "../env.ts";
 import { authLogger } from "../logger.ts";
 
-export const authRoutes = new Hono<{ Bindings: Env }>();
+export const authRoutes = new Hono<{ Bindings: Env }>()
+  /**
+   * ログアウトエンドポイント
+   * アプリのセッションを破棄し、Auth0側のセッションもクリアする。
+   * Auth0のログアウトエンドポイントにリダイレクトすることで、
+   * 次回アクセス時に別アカウントを選択できるようになる。
+   */
+  .get("/logout", async (c) => {
+    authLogger.info("Logout requested");
 
-/**
- * ログアウトエンドポイント
- * アプリのセッションを破棄し、Auth0側のセッションもクリアする。
- * Auth0のログアウトエンドポイントにリダイレクトすることで、
- * 次回アクセス時に別アカウントを選択できるようになる。
- */
-authRoutes.get("/logout", async (c) => {
-  authLogger.info("Logout requested");
+    await revokeSession(c);
 
-  await revokeSession(c);
+    const issuer = c.env.OIDC_ISSUER.replace(/\/$/, "");
+    const clientId = c.env.OIDC_CLIENT_ID;
+    const returnTo = new URL("/", c.req.url).toString();
+    const logoutUrl = `${issuer}/v2/logout?client_id=${clientId}&returnTo=${encodeURIComponent(returnTo)}`;
 
-  const issuer = c.env.OIDC_ISSUER.replace(/\/$/, "");
-  const clientId = c.env.OIDC_CLIENT_ID;
-  const returnTo = new URL("/", c.req.url).toString();
-  const logoutUrl = `${issuer}/v2/logout?client_id=${clientId}&returnTo=${encodeURIComponent(returnTo)}`;
-
-  authLogger.info("Session revoked, redirecting to Auth0 logout");
-  return c.redirect(logoutUrl);
-});
-
-/**
- * ログインユーザー情報取得エンドポイント
- * 認証済みユーザーの情報をJSONで返す
- * oidcAuthMiddleware() によって認証が保証されているため auth は非 null
- */
-authRoutes.get("/me", async (c) => {
-  const auth = await getAuth(c);
-  authLogger
-    .with({ email: auth?.email, sub: auth?.sub })
-    .info("User info requested for {email}", { email: auth?.email });
-  return c.json({
-    email: auth?.email,
-    sub: auth?.sub,
+    authLogger.info("Session revoked, redirecting to Auth0 logout");
+    return c.redirect(logoutUrl);
+  })
+  /**
+   * ログインユーザー情報取得エンドポイント
+   * 認証済みユーザーの情報をJSONで返す
+   * oidcAuthMiddleware() によって認証が保証されているため auth は非 null
+   */
+  .get("/me", async (c) => {
+    const auth = await getAuth(c);
+    authLogger
+      .with({ email: auth?.email, sub: auth?.sub })
+      .info("User info requested for {email}", { email: auth?.email });
+    return c.json({
+      email: auth?.email,
+      sub: auth?.sub,
+    });
   });
-});

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -3,38 +3,40 @@ import { Hono } from "hono";
 import type { Env } from "../env.ts";
 import { authLogger } from "../logger.ts";
 
-export const authRoutes = new Hono<{ Bindings: Env }>()
-  /**
-   * ログアウトエンドポイント
-   * アプリのセッションを破棄し、Auth0側のセッションもクリアする。
-   * Auth0のログアウトエンドポイントにリダイレクトすることで、
-   * 次回アクセス時に別アカウントを選択できるようになる。
-   */
-  .get("/logout", async (c) => {
-    authLogger.info("Logout requested");
+/**
+ * ログアウトエンドポイント
+ * アプリのセッションを破棄し、Auth0側のセッションもクリアする。
+ * Auth0のログアウトエンドポイントにリダイレクトすることで、
+ * 次回アクセス時に別アカウントを選択できるようになる。
+ */
+const logoutRoute = new Hono<{ Bindings: Env }>().get("/logout", async (c) => {
+  authLogger.info("Logout requested");
 
-    await revokeSession(c);
+  await revokeSession(c);
 
-    const issuer = c.env.OIDC_ISSUER.replace(/\/$/, "");
-    const clientId = c.env.OIDC_CLIENT_ID;
-    const returnTo = new URL("/", c.req.url).toString();
-    const logoutUrl = `${issuer}/v2/logout?client_id=${clientId}&returnTo=${encodeURIComponent(returnTo)}`;
+  const issuer = c.env.OIDC_ISSUER.replace(/\/$/, "");
+  const clientId = c.env.OIDC_CLIENT_ID;
+  const returnTo = new URL("/", c.req.url).toString();
+  const logoutUrl = `${issuer}/v2/logout?client_id=${clientId}&returnTo=${encodeURIComponent(returnTo)}`;
 
-    authLogger.info("Session revoked, redirecting to Auth0 logout");
-    return c.redirect(logoutUrl);
-  })
-  /**
-   * ログインユーザー情報取得エンドポイント
-   * 認証済みユーザーの情報をJSONで返す
-   * oidcAuthMiddleware() によって認証が保証されているため auth は非 null
-   */
-  .get("/me", async (c) => {
-    const auth = await getAuth(c);
-    authLogger
-      .with({ email: auth?.email, sub: auth?.sub })
-      .info("User info requested for {email}", { email: auth?.email });
-    return c.json({
-      email: auth?.email,
-      sub: auth?.sub,
-    });
+  authLogger.info("Session revoked, redirecting to Auth0 logout");
+  return c.redirect(logoutUrl);
+});
+
+/**
+ * ログインユーザー情報取得エンドポイント
+ * 認証済みユーザーの情報をJSONで返す
+ * oidcAuthMiddleware() によって認証が保証されているため auth は非 null
+ */
+const meRoute = new Hono<{ Bindings: Env }>().get("/me", async (c) => {
+  const auth = await getAuth(c);
+  authLogger
+    .with({ email: auth?.email, sub: auth?.sub })
+    .info("User info requested for {email}", { email: auth?.email });
+  return c.json({
+    email: auth?.email,
+    sub: auth?.sub,
   });
+});
+
+export const authRoutes = new Hono<{ Bindings: Env }>().route("/", logoutRoute).route("/", meRoute);

--- a/apps/server/src/routes/zaim.ts
+++ b/apps/server/src/routes/zaim.ts
@@ -47,132 +47,140 @@ const CallbackQuerySchema = v.object({
 type RequestTokenState = v.InferOutput<typeof RequestTokenStateSchema>;
 type StoredAccessToken = v.InferOutput<typeof StoredAccessTokenSchema>;
 
-export const zaimRoutes = new Hono<{ Bindings: Env }>()
-  /**
-   * Zaim OAuth 開始
-   *
-   * 1. Zaim から Request Token を取得
-   * 2. Request Token シークレットとユーザー sub を KV に一時保存
-   * 3. Zaim 認可画面へリダイレクト
-   */
-  .get("/zaim/auth/start", async (c) => {
-    const auth = await getAuth(c);
-    if (!auth?.sub) {
-      return c.json({ error: "Unauthorized" }, 401);
+/**
+ * Zaim OAuth 開始
+ *
+ * 1. Zaim から Request Token を取得
+ * 2. Request Token シークレットとユーザー sub を KV に一時保存
+ * 3. Zaim 認可画面へリダイレクト
+ */
+const startRoute = new Hono<{ Bindings: Env }>().get("/zaim/auth/start", async (c) => {
+  const auth = await getAuth(c);
+  if (!auth?.sub) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const callbackUrl = new URL("/zaim/auth/callback", c.req.url).toString();
+
+  const { oauthToken, oauthTokenSecret } = await fetchZaimRequestToken(
+    {
+      consumerKey: c.env.ZAIM_CONSUMER_KEY,
+      consumerSecret: c.env.ZAIM_CONSUMER_SECRET,
+    },
+    callbackUrl,
+  );
+
+  const state: RequestTokenState = {
+    tokenSecret: oauthTokenSecret,
+    userSub: auth.sub,
+  };
+
+  await c.env.ZAIM_KV.put(`zaim:request:${oauthToken}`, JSON.stringify(state), {
+    expirationTtl: REQUEST_TOKEN_TTL,
+  });
+
+  return c.redirect(buildZaimAuthorizeUrl(oauthToken));
+});
+
+/**
+ * Zaim OAuth コールバック
+ *
+ * Zaim 認可後に oauth_token と oauth_verifier を受け取り、
+ * Access Token を取得してユーザーの KV に保存する。
+ * ユーザー識別は Request Token 取得時に KV に保存した OIDC sub で行う。
+ */
+const callbackRoute = new Hono<{ Bindings: Env }>().get(
+  "/zaim/auth/callback",
+  sValidator("query", CallbackQuerySchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ error: "Missing oauth_token or oauth_verifier" }, 400);
+    }
+  }),
+  async (c) => {
+    const { oauth_token: oauthToken, oauth_verifier: oauthVerifier } = c.req.valid("query");
+
+    const stored = await c.env.ZAIM_KV.get(`zaim:request:${oauthToken}`);
+    if (!stored) {
+      return c.json({ error: "Request token not found or expired" }, 400);
     }
 
-    const callbackUrl = new URL("/zaim/auth/callback", c.req.url).toString();
+    const { tokenSecret, userSub } = v.parse(RequestTokenStateSchema, JSON.parse(stored));
 
-    const { oauthToken, oauthTokenSecret } = await fetchZaimRequestToken(
-      {
-        consumerKey: c.env.ZAIM_CONSUMER_KEY,
-        consumerSecret: c.env.ZAIM_CONSUMER_SECRET,
-      },
-      callbackUrl,
-    );
-
-    const state: RequestTokenState = {
-      tokenSecret: oauthTokenSecret,
-      userSub: auth.sub,
+    const accessConfig = {
+      consumerKey: c.env.ZAIM_CONSUMER_KEY,
+      consumerSecret: c.env.ZAIM_CONSUMER_SECRET,
+      token: oauthToken,
+      tokenSecret,
     };
 
-    await c.env.ZAIM_KV.put(`zaim:request:${oauthToken}`, JSON.stringify(state), {
-      expirationTtl: REQUEST_TOKEN_TTL,
-    });
+    const { oauthToken: accessToken, oauthTokenSecret } = await fetchZaimAccessToken(
+      accessConfig,
+      oauthVerifier,
+    );
 
-    return c.redirect(buildZaimAuthorizeUrl(oauthToken));
-  })
-  /**
-   * Zaim OAuth コールバック
-   *
-   * Zaim 認可後に oauth_token と oauth_verifier を受け取り、
-   * Access Token を取得してユーザーの KV に保存する。
-   * ユーザー識別は Request Token 取得時に KV に保存した OIDC sub で行う。
-   */
-  .get(
-    "/zaim/auth/callback",
-    sValidator("query", CallbackQuerySchema, (result, c) => {
-      if (!result.success) {
-        return c.json({ error: "Missing oauth_token or oauth_verifier" }, 400);
-      }
-    }),
-    async (c) => {
-      const { oauth_token: oauthToken, oauth_verifier: oauthVerifier } = c.req.valid("query");
+    const accessTokenConfig = {
+      consumerKey: c.env.ZAIM_CONSUMER_KEY,
+      consumerSecret: c.env.ZAIM_CONSUMER_SECRET,
+      token: accessToken,
+      tokenSecret: oauthTokenSecret,
+    };
 
-      const stored = await c.env.ZAIM_KV.get(`zaim:request:${oauthToken}`);
-      if (!stored) {
-        return c.json({ error: "Request token not found or expired" }, 400);
-      }
+    const zaimUserId = await fetchZaimUserId(accessTokenConfig);
 
-      const { tokenSecret, userSub } = v.parse(RequestTokenStateSchema, JSON.parse(stored));
+    const tokenData: StoredAccessToken = {
+      oauthToken: accessToken,
+      oauthTokenSecret,
+      zaimUserId,
+    };
 
-      const accessConfig = {
-        consumerKey: c.env.ZAIM_CONSUMER_KEY,
-        consumerSecret: c.env.ZAIM_CONSUMER_SECRET,
-        token: oauthToken,
-        tokenSecret,
-      };
+    // アクセストークンを永続保存
+    await c.env.ZAIM_KV.put(`zaim:token:${userSub}`, JSON.stringify(tokenData));
 
-      const { oauthToken: accessToken, oauthTokenSecret } = await fetchZaimAccessToken(
-        accessConfig,
-        oauthVerifier,
-      );
+    // 使用済み Request Token を削除
+    await c.env.ZAIM_KV.delete(`zaim:request:${oauthToken}`);
 
-      const accessTokenConfig = {
-        consumerKey: c.env.ZAIM_CONSUMER_KEY,
-        consumerSecret: c.env.ZAIM_CONSUMER_SECRET,
-        token: accessToken,
-        tokenSecret: oauthTokenSecret,
-      };
+    return c.json({ ok: true, zaimUserId });
+  },
+);
 
-      const zaimUserId = await fetchZaimUserId(accessTokenConfig);
+/**
+ * Zaim 連携状態確認
+ * アクセストークンが保存されているかどうかを返す。
+ */
+const statusRoute = new Hono<{ Bindings: Env }>().get("/zaim/auth/status", async (c) => {
+  const auth = await getAuth(c);
+  if (!auth) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
 
-      const tokenData: StoredAccessToken = {
-        oauthToken: accessToken,
-        oauthTokenSecret,
-        zaimUserId,
-      };
+  const stored = await c.env.ZAIM_KV.get(`zaim:token:${auth.sub}`);
+  if (!stored) {
+    return c.json({ connected: false });
+  }
 
-      // アクセストークンを永続保存
-      await c.env.ZAIM_KV.put(`zaim:token:${userSub}`, JSON.stringify(tokenData));
+  const { zaimUserId } = v.parse(StoredAccessTokenSchema, JSON.parse(stored));
+  return c.json({ connected: true, zaimUserId });
+});
 
-      // 使用済み Request Token を削除
-      await c.env.ZAIM_KV.delete(`zaim:request:${oauthToken}`);
+/**
+ * Zaim 連携解除
+ * KV に保存されたアクセストークンを削除する。
+ */
+const tokenRoute = new Hono<{ Bindings: Env }>().delete("/zaim/auth/token", async (c) => {
+  const auth = await getAuth(c);
+  if (!auth) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
 
-      return c.json({ ok: true, zaimUserId });
-    },
-  )
-  /**
-   * Zaim 連携状態確認
-   * アクセストークンが保存されているかどうかを返す。
-   */
-  .get("/zaim/auth/status", async (c) => {
-    const auth = await getAuth(c);
-    if (!auth) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
+  await c.env.ZAIM_KV.delete(`zaim:token:${auth.sub}`);
+  return c.json({ ok: true });
+});
 
-    const stored = await c.env.ZAIM_KV.get(`zaim:token:${auth.sub}`);
-    if (!stored) {
-      return c.json({ connected: false });
-    }
-
-    const { zaimUserId } = v.parse(StoredAccessTokenSchema, JSON.parse(stored));
-    return c.json({ connected: true, zaimUserId });
-  })
-  /**
-   * Zaim 連携解除
-   * KV に保存されたアクセストークンを削除する。
-   */
-  .delete("/zaim/auth/token", async (c) => {
-    const auth = await getAuth(c);
-    if (!auth) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
-
-    await c.env.ZAIM_KV.delete(`zaim:token:${auth.sub}`);
-    return c.json({ ok: true });
-  });
+export const zaimRoutes = new Hono<{ Bindings: Env }>()
+  .route("/", startRoute)
+  .route("/", callbackRoute)
+  .route("/", statusRoute)
+  .route("/", tokenRoute);
 
 /**
  * 指定ユーザーの Zaim アクセストークンを KV から取得するヘルパー

--- a/apps/server/src/routes/zaim.ts
+++ b/apps/server/src/routes/zaim.ts
@@ -24,8 +24,6 @@ import {
   fetchZaimUserId,
 } from "../zaim-oauth.ts";
 
-export const zaimRoutes = new Hono<{ Bindings: Env }>();
-
 /** Request Token の有効期限（秒） */
 const REQUEST_TOKEN_TTL = 600;
 
@@ -49,134 +47,132 @@ const CallbackQuerySchema = v.object({
 type RequestTokenState = v.InferOutput<typeof RequestTokenStateSchema>;
 type StoredAccessToken = v.InferOutput<typeof StoredAccessTokenSchema>;
 
-/**
- * Zaim OAuth 開始
- *
- * 1. Zaim から Request Token を取得
- * 2. Request Token シークレットとユーザー sub を KV に一時保存
- * 3. Zaim 認可画面へリダイレクト
- */
-zaimRoutes.get("/zaim/auth/start", async (c) => {
-  const auth = await getAuth(c);
-  if (!auth?.sub) {
-    return c.json({ error: "Unauthorized" }, 401);
-  }
-
-  const callbackUrl = new URL("/zaim/auth/callback", c.req.url).toString();
-
-  const { oauthToken, oauthTokenSecret } = await fetchZaimRequestToken(
-    {
-      consumerKey: c.env.ZAIM_CONSUMER_KEY,
-      consumerSecret: c.env.ZAIM_CONSUMER_SECRET,
-    },
-    callbackUrl,
-  );
-
-  const state: RequestTokenState = {
-    tokenSecret: oauthTokenSecret,
-    userSub: auth.sub,
-  };
-
-  await c.env.ZAIM_KV.put(`zaim:request:${oauthToken}`, JSON.stringify(state), {
-    expirationTtl: REQUEST_TOKEN_TTL,
-  });
-
-  return c.redirect(buildZaimAuthorizeUrl(oauthToken));
-});
-
-/**
- * Zaim OAuth コールバック
- *
- * Zaim 認可後に oauth_token と oauth_verifier を受け取り、
- * Access Token を取得してユーザーの KV に保存する。
- * ユーザー識別は Request Token 取得時に KV に保存した OIDC sub で行う。
- */
-zaimRoutes.get(
-  "/zaim/auth/callback",
-  sValidator("query", CallbackQuerySchema, (result, c) => {
-    if (!result.success) {
-      return c.json({ error: "Missing oauth_token or oauth_verifier" }, 400);
-    }
-  }),
-  async (c) => {
-    const { oauth_token: oauthToken, oauth_verifier: oauthVerifier } = c.req.valid("query");
-
-    const stored = await c.env.ZAIM_KV.get(`zaim:request:${oauthToken}`);
-    if (!stored) {
-      return c.json({ error: "Request token not found or expired" }, 400);
+export const zaimRoutes = new Hono<{ Bindings: Env }>()
+  /**
+   * Zaim OAuth 開始
+   *
+   * 1. Zaim から Request Token を取得
+   * 2. Request Token シークレットとユーザー sub を KV に一時保存
+   * 3. Zaim 認可画面へリダイレクト
+   */
+  .get("/zaim/auth/start", async (c) => {
+    const auth = await getAuth(c);
+    if (!auth?.sub) {
+      return c.json({ error: "Unauthorized" }, 401);
     }
 
-    const { tokenSecret, userSub } = v.parse(RequestTokenStateSchema, JSON.parse(stored));
+    const callbackUrl = new URL("/zaim/auth/callback", c.req.url).toString();
 
-    const accessConfig = {
-      consumerKey: c.env.ZAIM_CONSUMER_KEY,
-      consumerSecret: c.env.ZAIM_CONSUMER_SECRET,
-      token: oauthToken,
-      tokenSecret,
-    };
-
-    const { oauthToken: accessToken, oauthTokenSecret } = await fetchZaimAccessToken(
-      accessConfig,
-      oauthVerifier,
+    const { oauthToken, oauthTokenSecret } = await fetchZaimRequestToken(
+      {
+        consumerKey: c.env.ZAIM_CONSUMER_KEY,
+        consumerSecret: c.env.ZAIM_CONSUMER_SECRET,
+      },
+      callbackUrl,
     );
 
-    const accessTokenConfig = {
-      consumerKey: c.env.ZAIM_CONSUMER_KEY,
-      consumerSecret: c.env.ZAIM_CONSUMER_SECRET,
-      token: accessToken,
+    const state: RequestTokenState = {
       tokenSecret: oauthTokenSecret,
+      userSub: auth.sub,
     };
 
-    const zaimUserId = await fetchZaimUserId(accessTokenConfig);
+    await c.env.ZAIM_KV.put(`zaim:request:${oauthToken}`, JSON.stringify(state), {
+      expirationTtl: REQUEST_TOKEN_TTL,
+    });
 
-    const tokenData: StoredAccessToken = {
-      oauthToken: accessToken,
-      oauthTokenSecret,
-      zaimUserId,
-    };
+    return c.redirect(buildZaimAuthorizeUrl(oauthToken));
+  })
+  /**
+   * Zaim OAuth コールバック
+   *
+   * Zaim 認可後に oauth_token と oauth_verifier を受け取り、
+   * Access Token を取得してユーザーの KV に保存する。
+   * ユーザー識別は Request Token 取得時に KV に保存した OIDC sub で行う。
+   */
+  .get(
+    "/zaim/auth/callback",
+    sValidator("query", CallbackQuerySchema, (result, c) => {
+      if (!result.success) {
+        return c.json({ error: "Missing oauth_token or oauth_verifier" }, 400);
+      }
+    }),
+    async (c) => {
+      const { oauth_token: oauthToken, oauth_verifier: oauthVerifier } = c.req.valid("query");
 
-    // アクセストークンを永続保存
-    await c.env.ZAIM_KV.put(`zaim:token:${userSub}`, JSON.stringify(tokenData));
+      const stored = await c.env.ZAIM_KV.get(`zaim:request:${oauthToken}`);
+      if (!stored) {
+        return c.json({ error: "Request token not found or expired" }, 400);
+      }
 
-    // 使用済み Request Token を削除
-    await c.env.ZAIM_KV.delete(`zaim:request:${oauthToken}`);
+      const { tokenSecret, userSub } = v.parse(RequestTokenStateSchema, JSON.parse(stored));
 
-    return c.json({ ok: true, zaimUserId });
-  },
-);
+      const accessConfig = {
+        consumerKey: c.env.ZAIM_CONSUMER_KEY,
+        consumerSecret: c.env.ZAIM_CONSUMER_SECRET,
+        token: oauthToken,
+        tokenSecret,
+      };
 
-/**
- * Zaim 連携状態確認
- * アクセストークンが保存されているかどうかを返す。
- */
-zaimRoutes.get("/zaim/auth/status", async (c) => {
-  const auth = await getAuth(c);
-  if (!auth) {
-    return c.json({ error: "Unauthorized" }, 401);
-  }
+      const { oauthToken: accessToken, oauthTokenSecret } = await fetchZaimAccessToken(
+        accessConfig,
+        oauthVerifier,
+      );
 
-  const stored = await c.env.ZAIM_KV.get(`zaim:token:${auth.sub}`);
-  if (!stored) {
-    return c.json({ connected: false });
-  }
+      const accessTokenConfig = {
+        consumerKey: c.env.ZAIM_CONSUMER_KEY,
+        consumerSecret: c.env.ZAIM_CONSUMER_SECRET,
+        token: accessToken,
+        tokenSecret: oauthTokenSecret,
+      };
 
-  const { zaimUserId } = v.parse(StoredAccessTokenSchema, JSON.parse(stored));
-  return c.json({ connected: true, zaimUserId });
-});
+      const zaimUserId = await fetchZaimUserId(accessTokenConfig);
 
-/**
- * Zaim 連携解除
- * KV に保存されたアクセストークンを削除する。
- */
-zaimRoutes.delete("/zaim/auth/token", async (c) => {
-  const auth = await getAuth(c);
-  if (!auth) {
-    return c.json({ error: "Unauthorized" }, 401);
-  }
+      const tokenData: StoredAccessToken = {
+        oauthToken: accessToken,
+        oauthTokenSecret,
+        zaimUserId,
+      };
 
-  await c.env.ZAIM_KV.delete(`zaim:token:${auth.sub}`);
-  return c.json({ ok: true });
-});
+      // アクセストークンを永続保存
+      await c.env.ZAIM_KV.put(`zaim:token:${userSub}`, JSON.stringify(tokenData));
+
+      // 使用済み Request Token を削除
+      await c.env.ZAIM_KV.delete(`zaim:request:${oauthToken}`);
+
+      return c.json({ ok: true, zaimUserId });
+    },
+  )
+  /**
+   * Zaim 連携状態確認
+   * アクセストークンが保存されているかどうかを返す。
+   */
+  .get("/zaim/auth/status", async (c) => {
+    const auth = await getAuth(c);
+    if (!auth) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    const stored = await c.env.ZAIM_KV.get(`zaim:token:${auth.sub}`);
+    if (!stored) {
+      return c.json({ connected: false });
+    }
+
+    const { zaimUserId } = v.parse(StoredAccessTokenSchema, JSON.parse(stored));
+    return c.json({ connected: true, zaimUserId });
+  })
+  /**
+   * Zaim 連携解除
+   * KV に保存されたアクセストークンを削除する。
+   */
+  .delete("/zaim/auth/token", async (c) => {
+    const auth = await getAuth(c);
+    if (!auth) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    await c.env.ZAIM_KV.delete(`zaim:token:${auth.sub}`);
+    return c.json({ ok: true });
+  });
 
 /**
  * 指定ユーザーの Zaim アクセストークンを KV から取得するヘルパー

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,12 +57,18 @@ importers:
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      hono:
+        specifier: ^4.12.14
+        version: 4.12.14
       react:
         specifier: ^19.2.5
         version: 19.2.5
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      server:
+        specifier: workspace:*
+        version: link:../server
     devDependencies:
       '@storybook/react':
         specifier: ^10.3.5


### PR DESCRIPTION
## Summary
Refactored route definitions across the server to use Hono's method chaining pattern instead of separate route instantiation and handler registration. This improves code organization and enables proper TypeScript type inference for the application.

## Key Changes

- **Route definitions**: Converted `authRoutes` and `zaimRoutes` from separate instantiation to method chaining pattern, making route definitions more concise and readable
- **Main app setup**: Refactored `index.ts` to chain route handlers directly on the base Hono instance, improving clarity of route registration order
- **Type safety**: Added `AppType` export from `index.ts` to enable proper TypeScript type inference for API clients
- **Client generation**: Created new `client.ts` module that exports a `createClient` function using Hono's `hc` client generator for type-safe API calls
- **Extension integration**: Updated the extension's `App.tsx` to use the generated type-safe client instead of raw `fetch` calls, improving maintainability and reducing boilerplate
- **Package configuration**: Added `exports` field to `server/package.json` to properly expose the client module, and added `hono` and `server` workspace dependencies to the extension

## Implementation Details

- The method chaining pattern maintains the same functionality while improving code readability and reducing intermediate variable assignments
- Type-safe client generation leverages Hono's built-in client utilities, eliminating manual fetch call construction
- The `AppType` export ensures the client stays synchronized with server route definitions at compile time

https://claude.ai/code/session_01AV6FwB8duPNU4XxpDpb71S