### PR TITLE
Add comprehensive test suites for auth, zaim, and categories routes

### DIFF
--- a/apps/server/src/routes/auth.test.ts
+++ b/apps/server/src/routes/auth.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { beforeEach, describe, expect, test, vi } from "vite-plus/test";
+import { testClient } from "hono/testing";
 import { createKVNamespaceMock } from "../test-fixtures.ts";
 import { authRoutes } from "./auth.ts";
 import type { Env } from "../env.ts";
@@ -57,8 +58,7 @@ describe("GET /logout", () => {
   });
 
   test("Auth0のログアウトURLにリダイレクトする", async () => {
-    const env = makeEnv();
-    const res = await authRoutes.request("http://localhost/logout", {}, env);
+    const res = await testClient(authRoutes, makeEnv()).logout.$get();
 
     expect(res.status).toBe(302);
     const location = res.headers.get("Location") ?? "";
@@ -68,15 +68,16 @@ describe("GET /logout", () => {
   });
 
   test("ログアウトURL末尾スラッシュが重複しない", async () => {
-    const env = makeEnv({ OIDC_ISSUER: "https://example.auth0.com/" });
-    const res = await authRoutes.request("http://localhost/logout", {}, env);
+    const res = await testClient(
+      authRoutes,
+      makeEnv({ OIDC_ISSUER: "https://example.auth0.com/" }),
+    ).logout.$get();
     const location = res.headers.get("Location") ?? "";
     expect(location).not.toContain("auth0.com//");
   });
 
   test("revokeSessionを呼び出す", async () => {
-    const env = makeEnv();
-    await authRoutes.request("http://localhost/logout", {}, env);
+    await testClient(authRoutes, makeEnv()).logout.$get();
     expect(mockRevokeSession).toHaveBeenCalledOnce();
   });
 });
@@ -87,22 +88,20 @@ describe("GET /me", () => {
   test("認証済みユーザーのemailとsubを返す", async () => {
     mockGetAuth.mockResolvedValueOnce(MOCK_USER);
 
-    const env = makeEnv();
-    const res = await authRoutes.request("http://localhost/me", {}, env);
+    const res = await testClient(authRoutes, makeEnv()).me.$get();
     expect(res.status).toBe(200);
 
-    const body = await res.json<{ email?: string; sub?: string }>();
+    const body = await res.json();
     expect(body.email).toBe("user@example.com");
     expect(body.sub).toBe("auth0|user123");
   });
 
   test("getAuthがnullを返しても200を返す（ミドルウェアで保護済みのため）", async () => {
     mockGetAuth.mockResolvedValueOnce(null);
-    const env = makeEnv();
-    const res = await authRoutes.request("http://localhost/me", {}, env);
+    const res = await testClient(authRoutes, makeEnv()).me.$get();
     expect(res.status).toBe(200);
 
-    const body = await res.json<{ email?: string; sub?: string }>();
+    const body = await res.json();
     expect(body.email).toBeUndefined();
     expect(body.sub).toBeUndefined();
   });
@@ -113,43 +112,33 @@ describe("GET /me", () => {
 describe("GET /auth/launch", () => {
   test("有効なchromiumapp.orgのredirect_uriにリダイレクトする", async () => {
     const redirectUri = "https://abcdef.chromiumapp.org/callback";
-    const env = makeEnv();
-    const res = await authRoutes.request(
-      `http://localhost/auth/launch?redirect_uri=${encodeURIComponent(redirectUri)}`,
-      {},
-      env,
-    );
+    const res = await testClient(authRoutes, makeEnv()).auth.launch.$get({
+      query: { redirect_uri: redirectUri },
+    });
     expect(res.status).toBe(302);
     expect(res.headers.get("Location")).toBe(redirectUri);
   });
 
   test("redirect_uriが未指定のとき400を返す", async () => {
-    const env = makeEnv();
-    const res = await authRoutes.request("http://localhost/auth/launch", {}, env);
+    const res = await authRoutes.request("http://localhost/auth/launch", {}, makeEnv());
     expect(res.status).toBe(400);
-    const body = await res.json<{ error: string }>();
+    const body = (await res.json()) as { error: string };
     expect(body.error).toBeDefined();
   });
 
   test("chromiumapp.org以外のhostは400を返す", async () => {
-    const env = makeEnv();
-    const res = await authRoutes.request(
-      "http://localhost/auth/launch?redirect_uri=https://evil.example.com/cb",
-      {},
-      env,
-    );
+    const res = await testClient(authRoutes, makeEnv()).auth.launch.$get({
+      query: { redirect_uri: "https://evil.example.com/cb" },
+    });
     expect(res.status).toBe(400);
-    const body = await res.json<{ error: string }>();
+    const body = (await res.json()) as { error: string };
     expect(body.error).toMatch(/redirect_uri/);
   });
 
   test("httpスキームのURIは400を返す", async () => {
-    const env = makeEnv();
-    const res = await authRoutes.request(
-      "http://localhost/auth/launch?redirect_uri=http://abc.chromiumapp.org/cb",
-      {},
-      env,
-    );
+    const res = await testClient(authRoutes, makeEnv()).auth.launch.$get({
+      query: { redirect_uri: "http://abc.chromiumapp.org/cb" },
+    });
     expect(res.status).toBe(400);
   });
 });

--- a/apps/server/src/routes/auth.test.ts
+++ b/apps/server/src/routes/auth.test.ts
@@ -1,0 +1,155 @@
+/**
+ * auth ルートのテスト
+ *
+ * /logout  - セッション破棄 → Auth0 ログアウト URL へリダイレクト
+ * /me      - 認証済みユーザー情報を JSON で返す
+ * /auth/launch - 拡張機能向け認証起動（redirect_uri バリデーション）
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vite-plus/test";
+import { createKVNamespaceMock } from "../test-fixtures.ts";
+import { authRoutes } from "./auth.ts";
+import type { Env } from "../env.ts";
+import type { OidcAuth } from "@hono/oidc-auth";
+
+vi.mock("@hono/oidc-auth", () => ({
+  getAuth: vi.fn(),
+  revokeSession: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { getAuth, revokeSession } from "@hono/oidc-auth";
+
+const mockGetAuth = vi.mocked(getAuth);
+const mockRevokeSession = vi.mocked(revokeSession);
+
+const MOCK_USER = {
+  sub: "auth0|user123",
+  email: "user@example.com",
+  rtk: "",
+  rtkexp: 9999999999,
+  ssnexp: 9999999999,
+} as OidcAuth;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeEnv(overrides?: Partial<Env>): Env {
+  const { kv } = createKVNamespaceMock();
+  return {
+    OIDC_ISSUER: "https://example.auth0.com/",
+    OIDC_CLIENT_ID: "test_client_id",
+    OIDC_CLIENT_SECRET: "test_client_secret",
+    OIDC_REDIRECT_URI: "https://example.com/callback",
+    OIDC_AUTH_SECRET: "test_auth_secret_32chars_minimum!",
+    ZAIM_CONSUMER_KEY: "zaim_consumer_key",
+    ZAIM_CONSUMER_SECRET: "zaim_consumer_secret",
+    ZAIM_KV: kv,
+    ...overrides,
+  };
+}
+
+// ── /logout ──────────────────────────────────────────────────────────────────
+
+describe("GET /logout", () => {
+  beforeEach(() => {
+    mockRevokeSession.mockResolvedValue(undefined as unknown as void);
+  });
+
+  test("Auth0のログアウトURLにリダイレクトする", async () => {
+    const env = makeEnv();
+    const res = await authRoutes.request("http://localhost/logout", {}, env);
+
+    expect(res.status).toBe(302);
+    const location = res.headers.get("Location") ?? "";
+    expect(location).toContain("example.auth0.com");
+    expect(location).toContain("v2/logout");
+    expect(location).toContain("client_id=test_client_id");
+  });
+
+  test("ログアウトURL末尾スラッシュが重複しない", async () => {
+    const env = makeEnv({ OIDC_ISSUER: "https://example.auth0.com/" });
+    const res = await authRoutes.request("http://localhost/logout", {}, env);
+    const location = res.headers.get("Location") ?? "";
+    expect(location).not.toContain("auth0.com//");
+  });
+
+  test("revokeSessionを呼び出す", async () => {
+    const env = makeEnv();
+    await authRoutes.request("http://localhost/logout", {}, env);
+    expect(mockRevokeSession).toHaveBeenCalledOnce();
+  });
+});
+
+// ── /me ──────────────────────────────────────────────────────────────────────
+
+describe("GET /me", () => {
+  test("認証済みユーザーのemailとsubを返す", async () => {
+    mockGetAuth.mockResolvedValueOnce(MOCK_USER);
+
+    const env = makeEnv();
+    const res = await authRoutes.request("http://localhost/me", {}, env);
+    expect(res.status).toBe(200);
+
+    const body = await res.json<{ email?: string; sub?: string }>();
+    expect(body.email).toBe("user@example.com");
+    expect(body.sub).toBe("auth0|user123");
+  });
+
+  test("getAuthがnullを返しても200を返す（ミドルウェアで保護済みのため）", async () => {
+    mockGetAuth.mockResolvedValueOnce(null);
+    const env = makeEnv();
+    const res = await authRoutes.request("http://localhost/me", {}, env);
+    expect(res.status).toBe(200);
+
+    const body = await res.json<{ email?: string; sub?: string }>();
+    expect(body.email).toBeUndefined();
+    expect(body.sub).toBeUndefined();
+  });
+});
+
+// ── /auth/launch ─────────────────────────────────────────────────────────────
+
+describe("GET /auth/launch", () => {
+  test("有効なchromiumapp.orgのredirect_uriにリダイレクトする", async () => {
+    const redirectUri = "https://abcdef.chromiumapp.org/callback";
+    const env = makeEnv();
+    const res = await authRoutes.request(
+      `http://localhost/auth/launch?redirect_uri=${encodeURIComponent(redirectUri)}`,
+      {},
+      env,
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(redirectUri);
+  });
+
+  test("redirect_uriが未指定のとき400を返す", async () => {
+    const env = makeEnv();
+    const res = await authRoutes.request("http://localhost/auth/launch", {}, env);
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBeDefined();
+  });
+
+  test("chromiumapp.org以外のhostは400を返す", async () => {
+    const env = makeEnv();
+    const res = await authRoutes.request(
+      "http://localhost/auth/launch?redirect_uri=https://evil.example.com/cb",
+      {},
+      env,
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/redirect_uri/);
+  });
+
+  test("httpスキームのURIは400を返す", async () => {
+    const env = makeEnv();
+    const res = await authRoutes.request(
+      "http://localhost/auth/launch?redirect_uri=http://abc.chromiumapp.org/cb",
+      {},
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/server/src/routes/categories.test.ts
+++ b/apps/server/src/routes/categories.test.ts
@@ -1,0 +1,215 @@
+/**
+ * categories ルートのテスト
+ *
+ * GET /api/zaim/categories - カテゴリ＋サブカテゴリ一覧（KVキャッシュ付き）
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vite-plus/test";
+import { createKVNamespaceMock } from "../test-fixtures.ts";
+import { categoriesRoutes } from "./categories.ts";
+import type { Env } from "../env.ts";
+import type { KVNamespace } from "@cloudflare/workers-types";
+import type { OidcAuth } from "@hono/oidc-auth";
+
+vi.mock("@hono/oidc-auth", () => ({
+  getAuth: vi.fn(),
+  revokeSession: vi.fn().mockResolvedValue(undefined),
+}));
+
+// vi.hoisted を使って @repo/zaim-api を import せずにモック関数を定義する
+// (@repo/zaim-api は型生成が必要なため直接 import すると TypeScript エラーになる)
+const { mockGetCategories, mockGetGenres } = vi.hoisted(() => ({
+  mockGetCategories: vi.fn(),
+  mockGetGenres: vi.fn(),
+}));
+
+vi.mock("@repo/zaim-api", () => ({
+  categoryGetCategories: mockGetCategories,
+  genreGetGenres: mockGetGenres,
+}));
+
+vi.mock("@repo/zaim-api/client", () => ({
+  createClient: vi.fn(() => ({
+    interceptors: { request: { use: vi.fn() } },
+  })),
+}));
+
+vi.mock("@repo/zaim-api/oauth/interceptor", () => ({
+  createZaimAuthInterceptor: vi.fn(() => () => {}),
+}));
+
+import { getAuth } from "@hono/oidc-auth";
+
+const mockGetAuth = vi.mocked(getAuth);
+
+const MOCK_USER = {
+  sub: "auth0|user123",
+  email: "user@example.com",
+  rtk: "",
+  rtkexp: 9999999999,
+  ssnexp: 9999999999,
+} as OidcAuth;
+
+const STORED_TOKEN = JSON.stringify({
+  oauthToken: "access_token",
+  oauthTokenSecret: "access_secret",
+  zaimUserId: "zaim_user_999",
+});
+
+const MOCK_CATEGORIES_RESPONSE = {
+  categories: [
+    { id: 101, name: "食費", mode: "payment" },
+    { id: 102, name: "給与", mode: "income" },
+  ],
+};
+
+const MOCK_GENRES_RESPONSE = {
+  genres: [
+    { id: 201, name: "外食", category_id: 101 },
+    { id: 202, name: "食材", category_id: 101 },
+    { id: 203, name: "月給", category_id: 102 },
+  ],
+};
+
+function makeEnv(kvOverride?: KVNamespace): Env {
+  const { kv } = createKVNamespaceMock();
+  return {
+    OIDC_ISSUER: "https://example.auth0.com/",
+    OIDC_CLIENT_ID: "test_client_id",
+    OIDC_CLIENT_SECRET: "test_client_secret",
+    OIDC_REDIRECT_URI: "https://example.com/callback",
+    OIDC_AUTH_SECRET: "test_auth_secret_32chars_minimum!",
+    ZAIM_CONSUMER_KEY: "zaim_consumer_key",
+    ZAIM_CONSUMER_SECRET: "zaim_consumer_secret",
+    ZAIM_KV: kvOverride ?? kv,
+  };
+}
+
+// ── GET /api/zaim/categories ──────────────────────────────────────────────────
+
+describe("GET /api/zaim/categories", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuth.mockResolvedValue(MOCK_USER);
+    mockGetCategories.mockResolvedValue({ data: MOCK_CATEGORIES_RESPONSE });
+    mockGetGenres.mockResolvedValue({ data: MOCK_GENRES_RESPONSE });
+  });
+
+  test("OIDC未認証のとき401を返す", async () => {
+    mockGetAuth.mockResolvedValueOnce(null);
+    const res = await categoriesRoutes.request(
+      "http://localhost/api/zaim/categories",
+      {},
+      makeEnv(),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("Zaimトークン未連携のとき403を返す", async () => {
+    const res = await categoriesRoutes.request(
+      "http://localhost/api/zaim/categories",
+      {},
+      makeEnv(),
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/Zaim/);
+  });
+
+  test("KVキャッシュヒット時はZaim APIを呼ばずにキャッシュを返す", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    const cachedData = {
+      fetchedAt: "2026-01-01T00:00:00.000Z",
+      categories: [{ id: 101, name: "食費", mode: "payment", subCategories: [] }],
+    };
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(JSON.stringify(cachedData));
+
+    const res = await categoriesRoutes.request(
+      "http://localhost/api/zaim/categories",
+      {},
+      makeEnv(kv),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<typeof cachedData>();
+    expect(body.fetchedAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(mockGetCategories).not.toHaveBeenCalled();
+    expect(mockGetGenres).not.toHaveBeenCalled();
+  });
+
+  test("キャッシュミス時はZaim APIを呼んでカテゴリを返す", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
+
+    const res = await categoriesRoutes.request(
+      "http://localhost/api/zaim/categories",
+      {},
+      makeEnv(kv),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<{ fetchedAt: string; categories: unknown[] }>();
+    expect(body.categories).toHaveLength(2);
+    expect(mockGetCategories).toHaveBeenCalledOnce();
+    expect(mockGetGenres).toHaveBeenCalledOnce();
+  });
+
+  test("カテゴリ取得後にKVへキャッシュを書き込む", async () => {
+    const { kv, mockGet, mockPut } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
+
+    await categoriesRoutes.request("http://localhost/api/zaim/categories", {}, makeEnv(kv));
+
+    expect(mockPut).toHaveBeenCalledWith(
+      "zaim:cache:categories:zaim_user_999",
+      expect.any(String),
+      { expirationTtl: 86400 },
+    );
+  });
+
+  test("ジャンルがカテゴリのsubCategoriesにネストされる", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
+
+    const res = await categoriesRoutes.request(
+      "http://localhost/api/zaim/categories",
+      {},
+      makeEnv(kv),
+    );
+    const body = await res.json<{
+      categories: { id: number; subCategories: { id: number; name: string }[] }[];
+    }>();
+
+    const shokuhi = body.categories.find((c) => c.id === 101);
+    expect(shokuhi?.subCategories).toHaveLength(2);
+    expect(shokuhi?.subCategories.map((s) => s.id)).toEqual([201, 202]);
+  });
+
+  test("no_cache=1のときKVキャッシュを無視してAPIを呼ぶ", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    const cachedData = { fetchedAt: "2026-01-01T00:00:00.000Z", categories: [] };
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(JSON.stringify(cachedData));
+
+    const res = await categoriesRoutes.request(
+      "http://localhost/api/zaim/categories?no_cache=1",
+      {},
+      makeEnv(kv),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<{ categories: unknown[] }>();
+    expect(body.categories).toHaveLength(2);
+    expect(mockGetCategories).toHaveBeenCalledOnce();
+  });
+
+  test("レスポンスにfetchedAt（ISO 8601）が含まれる", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
+
+    const res = await categoriesRoutes.request(
+      "http://localhost/api/zaim/categories",
+      {},
+      makeEnv(kv),
+    );
+    const body = await res.json<{ fetchedAt: string }>();
+    expect(() => new Date(body.fetchedAt)).not.toThrow();
+    expect(body.fetchedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});

--- a/apps/server/src/routes/categories.test.ts
+++ b/apps/server/src/routes/categories.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { beforeEach, describe, expect, test, vi } from "vite-plus/test";
+import { testClient } from "hono/testing";
 import { createKVNamespaceMock } from "../test-fixtures.ts";
 import { categoriesRoutes } from "./categories.ts";
 import type { Env } from "../env.ts";
@@ -97,22 +98,18 @@ describe("GET /api/zaim/categories", () => {
 
   test("OIDC未認証のとき401を返す", async () => {
     mockGetAuth.mockResolvedValueOnce(null);
-    const res = await categoriesRoutes.request(
-      "http://localhost/api/zaim/categories",
-      {},
-      makeEnv(),
-    );
+    const res = await testClient(categoriesRoutes, makeEnv()).api.zaim.categories.$get({
+      query: {},
+    });
     expect(res.status).toBe(401);
   });
 
   test("Zaimトークン未連携のとき403を返す", async () => {
-    const res = await categoriesRoutes.request(
-      "http://localhost/api/zaim/categories",
-      {},
-      makeEnv(),
-    );
+    const res = await testClient(categoriesRoutes, makeEnv()).api.zaim.categories.$get({
+      query: {},
+    });
     expect(res.status).toBe(403);
-    const body = await res.json<{ error: string }>();
+    const body = (await res.json()) as { error: string };
     expect(body.error).toMatch(/Zaim/);
   });
 
@@ -124,13 +121,11 @@ describe("GET /api/zaim/categories", () => {
     };
     mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(JSON.stringify(cachedData));
 
-    const res = await categoriesRoutes.request(
-      "http://localhost/api/zaim/categories",
-      {},
-      makeEnv(kv),
-    );
+    const res = await testClient(categoriesRoutes, makeEnv(kv)).api.zaim.categories.$get({
+      query: {},
+    });
     expect(res.status).toBe(200);
-    const body = await res.json<typeof cachedData>();
+    const body = (await res.json()) as typeof cachedData;
     expect(body.fetchedAt).toBe("2026-01-01T00:00:00.000Z");
     expect(mockGetCategories).not.toHaveBeenCalled();
     expect(mockGetGenres).not.toHaveBeenCalled();
@@ -140,13 +135,11 @@ describe("GET /api/zaim/categories", () => {
     const { kv, mockGet } = createKVNamespaceMock();
     mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
 
-    const res = await categoriesRoutes.request(
-      "http://localhost/api/zaim/categories",
-      {},
-      makeEnv(kv),
-    );
+    const res = await testClient(categoriesRoutes, makeEnv(kv)).api.zaim.categories.$get({
+      query: {},
+    });
     expect(res.status).toBe(200);
-    const body = await res.json<{ fetchedAt: string; categories: unknown[] }>();
+    const body = (await res.json()) as { fetchedAt: string; categories: unknown[] };
     expect(body.categories).toHaveLength(2);
     expect(mockGetCategories).toHaveBeenCalledOnce();
     expect(mockGetGenres).toHaveBeenCalledOnce();
@@ -156,7 +149,7 @@ describe("GET /api/zaim/categories", () => {
     const { kv, mockGet, mockPut } = createKVNamespaceMock();
     mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
 
-    await categoriesRoutes.request("http://localhost/api/zaim/categories", {}, makeEnv(kv));
+    await testClient(categoriesRoutes, makeEnv(kv)).api.zaim.categories.$get({ query: {} });
 
     expect(mockPut).toHaveBeenCalledWith(
       "zaim:cache:categories:zaim_user_999",
@@ -169,14 +162,12 @@ describe("GET /api/zaim/categories", () => {
     const { kv, mockGet } = createKVNamespaceMock();
     mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
 
-    const res = await categoriesRoutes.request(
-      "http://localhost/api/zaim/categories",
-      {},
-      makeEnv(kv),
-    );
-    const body = await res.json<{
+    const res = await testClient(categoriesRoutes, makeEnv(kv)).api.zaim.categories.$get({
+      query: {},
+    });
+    const body = (await res.json()) as {
       categories: { id: number; subCategories: { id: number; name: string }[] }[];
-    }>();
+    };
 
     const shokuhi = body.categories.find((c) => c.id === 101);
     expect(shokuhi?.subCategories).toHaveLength(2);
@@ -188,13 +179,11 @@ describe("GET /api/zaim/categories", () => {
     const cachedData = { fetchedAt: "2026-01-01T00:00:00.000Z", categories: [] };
     mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(JSON.stringify(cachedData));
 
-    const res = await categoriesRoutes.request(
-      "http://localhost/api/zaim/categories?no_cache=1",
-      {},
-      makeEnv(kv),
-    );
+    const res = await testClient(categoriesRoutes, makeEnv(kv)).api.zaim.categories.$get({
+      query: { no_cache: "1" },
+    });
     expect(res.status).toBe(200);
-    const body = await res.json<{ categories: unknown[] }>();
+    const body = (await res.json()) as { categories: unknown[] };
     expect(body.categories).toHaveLength(2);
     expect(mockGetCategories).toHaveBeenCalledOnce();
   });
@@ -203,12 +192,10 @@ describe("GET /api/zaim/categories", () => {
     const { kv, mockGet } = createKVNamespaceMock();
     mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
 
-    const res = await categoriesRoutes.request(
-      "http://localhost/api/zaim/categories",
-      {},
-      makeEnv(kv),
-    );
-    const body = await res.json<{ fetchedAt: string }>();
+    const res = await testClient(categoriesRoutes, makeEnv(kv)).api.zaim.categories.$get({
+      query: {},
+    });
+    const body = (await res.json()) as { fetchedAt: string };
     expect(() => new Date(body.fetchedAt)).not.toThrow();
     expect(body.fetchedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });

--- a/apps/server/src/routes/zaim.test.ts
+++ b/apps/server/src/routes/zaim.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { beforeEach, describe, expect, test, vi } from "vite-plus/test";
+import { testClient } from "hono/testing";
 import { createKVNamespaceMock } from "../test-fixtures.ts";
 import { zaimRoutes } from "./zaim.ts";
 import type { Env } from "../env.ts";
@@ -72,12 +73,12 @@ describe("GET /zaim/auth/start", () => {
 
   test("OIDC未認証のとき401を返す", async () => {
     mockGetAuth.mockResolvedValueOnce(null);
-    const res = await zaimRoutes.request("http://localhost/zaim/auth/start", {}, makeEnv());
+    const res = await testClient(zaimRoutes, makeEnv()).zaim.auth.start.$get({ query: {} });
     expect(res.status).toBe(401);
   });
 
   test("通常フロー: Zaim認可URLへリダイレクトする", async () => {
-    const res = await zaimRoutes.request("http://localhost/zaim/auth/start", {}, makeEnv());
+    const res = await testClient(zaimRoutes, makeEnv()).zaim.auth.start.$get({ query: {} });
     expect(res.status).toBe(302);
     const location = res.headers.get("Location") ?? "";
     expect(location).toContain("auth.zaim.net");
@@ -86,7 +87,7 @@ describe("GET /zaim/auth/start", () => {
 
   test("通常フロー: Request TokenをKVに保存する", async () => {
     const { kv, mockPut } = createKVNamespaceMock();
-    await zaimRoutes.request("http://localhost/zaim/auth/start", {}, makeEnv(kv));
+    await testClient(zaimRoutes, makeEnv(kv)).zaim.auth.start.$get({ query: {} });
     expect(mockPut).toHaveBeenCalledWith(
       "zaim:request:req_token_abc",
       expect.stringContaining("req_secret_xyz"),
@@ -96,33 +97,27 @@ describe("GET /zaim/auth/start", () => {
 
   test("拡張機能フロー: ext_redirect_uriを指定するとauthorizeUrlをJSONで返す", async () => {
     const extUri = "https://abc.chromiumapp.org/callback";
-    const res = await zaimRoutes.request(
-      `http://localhost/zaim/auth/start?ext_redirect_uri=${encodeURIComponent(extUri)}`,
-      {},
-      makeEnv(),
-    );
+    const res = await testClient(zaimRoutes, makeEnv()).zaim.auth.start.$get({
+      query: { ext_redirect_uri: extUri },
+    });
     expect(res.status).toBe(200);
-    const body = await res.json<{ authorizeUrl: string }>();
+    const body = (await res.json()) as { authorizeUrl: string };
     expect(body.authorizeUrl).toContain("auth.zaim.net");
   });
 
   test("拡張機能フロー: ext_redirect_uriにはchromiumapp.orgのみ許可", async () => {
-    const res = await zaimRoutes.request(
-      "http://localhost/zaim/auth/start?ext_redirect_uri=https://evil.example.com/cb",
-      {},
-      makeEnv(),
-    );
+    const res = await testClient(zaimRoutes, makeEnv()).zaim.auth.start.$get({
+      query: { ext_redirect_uri: "https://evil.example.com/cb" },
+    });
     expect(res.status).toBe(400);
   });
 
   test("KVのRequestTokenStateにuserSubとextRedirectUriが入る", async () => {
     const { kv, mockPut } = createKVNamespaceMock();
     const extUri = "https://abc.chromiumapp.org/callback";
-    await zaimRoutes.request(
-      `http://localhost/zaim/auth/start?ext_redirect_uri=${encodeURIComponent(extUri)}`,
-      {},
-      makeEnv(kv),
-    );
+    await testClient(zaimRoutes, makeEnv(kv)).zaim.auth.start.$get({
+      query: { ext_redirect_uri: extUri },
+    });
     const [, storedJson] = mockPut.mock.calls[0] as unknown as [string, string, unknown];
     const state = JSON.parse(storedJson) as { userSub: string; extRedirectUri: string };
     expect(state.userSub).toBe(MOCK_USER.sub);
@@ -158,11 +153,9 @@ describe("GET /zaim/auth/callback", () => {
   });
 
   test("KVにRequest Tokenが存在しない場合400を返す", async () => {
-    const res = await zaimRoutes.request(
-      "http://localhost/zaim/auth/callback?oauth_token=unknown&oauth_verifier=ver",
-      {},
-      makeEnv(),
-    );
+    const res = await testClient(zaimRoutes, makeEnv()).zaim.auth.callback.$get({
+      query: { oauth_token: "unknown", oauth_verifier: "ver" },
+    });
     expect(res.status).toBe(400);
   });
 
@@ -170,13 +163,11 @@ describe("GET /zaim/auth/callback", () => {
     const { kv, mockGet } = createKVNamespaceMock();
     mockGet.mockResolvedValueOnce(storedState);
 
-    const res = await zaimRoutes.request(
-      "http://localhost/zaim/auth/callback?oauth_token=req_token_abc&oauth_verifier=verifier123",
-      {},
-      makeEnv(kv),
-    );
+    const res = await testClient(zaimRoutes, makeEnv(kv)).zaim.auth.callback.$get({
+      query: { oauth_token: "req_token_abc", oauth_verifier: "verifier123" },
+    });
     expect(res.status).toBe(200);
-    const body = await res.json<{ ok: boolean; zaimUserId: string }>();
+    const body = (await res.json()) as { ok: boolean; zaimUserId: string };
     expect(body.ok).toBe(true);
     expect(body.zaimUserId).toBe("zaim_user_999");
   });
@@ -185,11 +176,9 @@ describe("GET /zaim/auth/callback", () => {
     const { kv, mockGet, mockPut } = createKVNamespaceMock();
     mockGet.mockResolvedValueOnce(storedState);
 
-    await zaimRoutes.request(
-      "http://localhost/zaim/auth/callback?oauth_token=req_token_abc&oauth_verifier=verifier123",
-      {},
-      makeEnv(kv),
-    );
+    await testClient(zaimRoutes, makeEnv(kv)).zaim.auth.callback.$get({
+      query: { oauth_token: "req_token_abc", oauth_verifier: "verifier123" },
+    });
 
     const [putKey, putVal] = mockPut.mock.calls[0] as [string, string];
     expect(putKey).toBe("zaim:token:auth0|user123");
@@ -202,11 +191,9 @@ describe("GET /zaim/auth/callback", () => {
     const { kv, mockGet, mockDelete } = createKVNamespaceMock();
     mockGet.mockResolvedValueOnce(storedState);
 
-    await zaimRoutes.request(
-      "http://localhost/zaim/auth/callback?oauth_token=req_token_abc&oauth_verifier=verifier123",
-      {},
-      makeEnv(kv),
-    );
+    await testClient(zaimRoutes, makeEnv(kv)).zaim.auth.callback.$get({
+      query: { oauth_token: "req_token_abc", oauth_verifier: "verifier123" },
+    });
 
     expect(mockDelete).toHaveBeenCalledWith("zaim:request:req_token_abc");
   });
@@ -222,11 +209,9 @@ describe("GET /zaim/auth/callback", () => {
     const { kv, mockGet } = createKVNamespaceMock();
     mockGet.mockResolvedValueOnce(stateWithExt);
 
-    const res = await zaimRoutes.request(
-      "http://localhost/zaim/auth/callback?oauth_token=req_token_abc&oauth_verifier=verifier123",
-      {},
-      makeEnv(kv),
-    );
+    const res = await testClient(zaimRoutes, makeEnv(kv)).zaim.auth.callback.$get({
+      query: { oauth_token: "req_token_abc", oauth_verifier: "verifier123" },
+    });
     expect(res.status).toBe(302);
     expect(res.headers.get("Location")).toBe(extUri);
   });
@@ -242,14 +227,14 @@ describe("GET /zaim/auth/status", () => {
 
   test("OIDC未認証のとき401を返す", async () => {
     mockGetAuth.mockResolvedValueOnce(null);
-    const res = await zaimRoutes.request("http://localhost/zaim/auth/status", {}, makeEnv());
+    const res = await testClient(zaimRoutes, makeEnv()).zaim.auth.status.$get({});
     expect(res.status).toBe(401);
   });
 
   test("KVにトークンがない場合 connected: false を返す", async () => {
-    const res = await zaimRoutes.request("http://localhost/zaim/auth/status", {}, makeEnv());
+    const res = await testClient(zaimRoutes, makeEnv()).zaim.auth.status.$get({});
     expect(res.status).toBe(200);
-    const body = await res.json<{ connected: boolean }>();
+    const body = (await res.json()) as { connected: boolean };
     expect(body.connected).toBe(false);
   });
 
@@ -262,16 +247,16 @@ describe("GET /zaim/auth/status", () => {
     });
     mockGet.mockResolvedValueOnce(stored);
 
-    const res = await zaimRoutes.request("http://localhost/zaim/auth/status", {}, makeEnv(kv));
+    const res = await testClient(zaimRoutes, makeEnv(kv)).zaim.auth.status.$get({});
     expect(res.status).toBe(200);
-    const body = await res.json<{ connected: boolean; zaimUserId: string }>();
+    const body = (await res.json()) as { connected: boolean; zaimUserId: string };
     expect(body.connected).toBe(true);
     expect(body.zaimUserId).toBe("zaim_user_999");
   });
 
   test("ユーザーのsubに対応するKVキーを参照する", async () => {
     const { kv, mockGet } = createKVNamespaceMock();
-    await zaimRoutes.request("http://localhost/zaim/auth/status", {}, makeEnv(kv));
+    await testClient(zaimRoutes, makeEnv(kv)).zaim.auth.status.$get({});
     expect(mockGet).toHaveBeenCalledWith("zaim:token:auth0|user123");
   });
 });
@@ -286,23 +271,15 @@ describe("DELETE /zaim/auth/token", () => {
 
   test("OIDC未認証のとき401を返す", async () => {
     mockGetAuth.mockResolvedValueOnce(null);
-    const res = await zaimRoutes.request(
-      "http://localhost/zaim/auth/token",
-      { method: "DELETE" },
-      makeEnv(),
-    );
+    const res = await testClient(zaimRoutes, makeEnv()).zaim.auth.token.$delete();
     expect(res.status).toBe(401);
   });
 
   test("KVからアクセストークンを削除して ok: true を返す", async () => {
     const { kv, mockDelete } = createKVNamespaceMock();
-    const res = await zaimRoutes.request(
-      "http://localhost/zaim/auth/token",
-      { method: "DELETE" },
-      makeEnv(kv),
-    );
+    const res = await testClient(zaimRoutes, makeEnv(kv)).zaim.auth.token.$delete();
     expect(res.status).toBe(200);
-    const body = await res.json<{ ok: boolean }>();
+    const body = (await res.json()) as { ok: boolean };
     expect(body.ok).toBe(true);
     expect(mockDelete).toHaveBeenCalledWith("zaim:token:auth0|user123");
   });

--- a/apps/server/src/routes/zaim.test.ts
+++ b/apps/server/src/routes/zaim.test.ts
@@ -1,0 +1,309 @@
+/**
+ * zaim ルートのテスト
+ *
+ * GET  /zaim/auth/start    - Zaim OAuth 開始
+ * GET  /zaim/auth/callback - Zaim からのコールバック
+ * GET  /zaim/auth/status   - Zaim 連携状態確認
+ * DELETE /zaim/auth/token  - Zaim 連携解除
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vite-plus/test";
+import { createKVNamespaceMock } from "../test-fixtures.ts";
+import { zaimRoutes } from "./zaim.ts";
+import type { Env } from "../env.ts";
+import type { KVNamespace } from "@cloudflare/workers-types";
+import type { OidcAuth } from "@hono/oidc-auth";
+
+vi.mock("@hono/oidc-auth", () => ({
+  getAuth: vi.fn(),
+  revokeSession: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../zaim-oauth.ts", () => ({
+  fetchZaimRequestToken: vi.fn(),
+  fetchZaimAccessToken: vi.fn(),
+  fetchZaimUserId: vi.fn(),
+  buildZaimAuthorizeUrl: vi.fn(
+    (token: string) => `https://auth.zaim.net/users/auth?oauth_token=${token}`,
+  ),
+}));
+
+import { getAuth } from "@hono/oidc-auth";
+import { fetchZaimRequestToken, fetchZaimAccessToken, fetchZaimUserId } from "../zaim-oauth.ts";
+
+const mockGetAuth = vi.mocked(getAuth);
+const mockFetchRequestToken = vi.mocked(fetchZaimRequestToken);
+const mockFetchAccessToken = vi.mocked(fetchZaimAccessToken);
+const mockFetchUserId = vi.mocked(fetchZaimUserId);
+
+const MOCK_USER = {
+  sub: "auth0|user123",
+  email: "user@example.com",
+  rtk: "",
+  rtkexp: 9999999999,
+  ssnexp: 9999999999,
+} as OidcAuth;
+
+function makeEnv(kvOverride?: KVNamespace): Env {
+  const { kv } = createKVNamespaceMock();
+  return {
+    OIDC_ISSUER: "https://example.auth0.com/",
+    OIDC_CLIENT_ID: "test_client_id",
+    OIDC_CLIENT_SECRET: "test_client_secret",
+    OIDC_REDIRECT_URI: "https://example.com/callback",
+    OIDC_AUTH_SECRET: "test_auth_secret_32chars_minimum!",
+    ZAIM_CONSUMER_KEY: "zaim_consumer_key",
+    ZAIM_CONSUMER_SECRET: "zaim_consumer_secret",
+    ZAIM_KV: kvOverride ?? kv,
+  };
+}
+
+// ── GET /zaim/auth/start ──────────────────────────────────────────────────────
+
+describe("GET /zaim/auth/start", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuth.mockResolvedValue(MOCK_USER);
+    mockFetchRequestToken.mockResolvedValue({
+      oauthToken: "req_token_abc",
+      oauthTokenSecret: "req_secret_xyz",
+    });
+  });
+
+  test("OIDC未認証のとき401を返す", async () => {
+    mockGetAuth.mockResolvedValueOnce(null);
+    const res = await zaimRoutes.request("http://localhost/zaim/auth/start", {}, makeEnv());
+    expect(res.status).toBe(401);
+  });
+
+  test("通常フロー: Zaim認可URLへリダイレクトする", async () => {
+    const res = await zaimRoutes.request("http://localhost/zaim/auth/start", {}, makeEnv());
+    expect(res.status).toBe(302);
+    const location = res.headers.get("Location") ?? "";
+    expect(location).toContain("auth.zaim.net");
+    expect(location).toContain("req_token_abc");
+  });
+
+  test("通常フロー: Request TokenをKVに保存する", async () => {
+    const { kv, mockPut } = createKVNamespaceMock();
+    await zaimRoutes.request("http://localhost/zaim/auth/start", {}, makeEnv(kv));
+    expect(mockPut).toHaveBeenCalledWith(
+      "zaim:request:req_token_abc",
+      expect.stringContaining("req_secret_xyz"),
+      { expirationTtl: 600 },
+    );
+  });
+
+  test("拡張機能フロー: ext_redirect_uriを指定するとauthorizeUrlをJSONで返す", async () => {
+    const extUri = "https://abc.chromiumapp.org/callback";
+    const res = await zaimRoutes.request(
+      `http://localhost/zaim/auth/start?ext_redirect_uri=${encodeURIComponent(extUri)}`,
+      {},
+      makeEnv(),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<{ authorizeUrl: string }>();
+    expect(body.authorizeUrl).toContain("auth.zaim.net");
+  });
+
+  test("拡張機能フロー: ext_redirect_uriにはchromiumapp.orgのみ許可", async () => {
+    const res = await zaimRoutes.request(
+      "http://localhost/zaim/auth/start?ext_redirect_uri=https://evil.example.com/cb",
+      {},
+      makeEnv(),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("KVのRequestTokenStateにuserSubとextRedirectUriが入る", async () => {
+    const { kv, mockPut } = createKVNamespaceMock();
+    const extUri = "https://abc.chromiumapp.org/callback";
+    await zaimRoutes.request(
+      `http://localhost/zaim/auth/start?ext_redirect_uri=${encodeURIComponent(extUri)}`,
+      {},
+      makeEnv(kv),
+    );
+    const [, storedJson] = mockPut.mock.calls[0] as unknown as [string, string, unknown];
+    const state = JSON.parse(storedJson) as { userSub: string; extRedirectUri: string };
+    expect(state.userSub).toBe(MOCK_USER.sub);
+    expect(state.extRedirectUri).toBe(extUri);
+  });
+});
+
+// ── GET /zaim/auth/callback ───────────────────────────────────────────────────
+
+describe("GET /zaim/auth/callback", () => {
+  const storedState = JSON.stringify({
+    tokenSecret: "req_secret_xyz",
+    userSub: "auth0|user123",
+    extRedirectUri: undefined,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchAccessToken.mockResolvedValue({
+      oauthToken: "access_token_abc",
+      oauthTokenSecret: "access_secret_xyz",
+    });
+    mockFetchUserId.mockResolvedValue("zaim_user_999");
+  });
+
+  test("oauth_tokenまたはoauth_verifierが欠けると400を返す", async () => {
+    const res = await zaimRoutes.request(
+      "http://localhost/zaim/auth/callback?oauth_token=tok",
+      {},
+      makeEnv(),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("KVにRequest Tokenが存在しない場合400を返す", async () => {
+    const res = await zaimRoutes.request(
+      "http://localhost/zaim/auth/callback?oauth_token=unknown&oauth_verifier=ver",
+      {},
+      makeEnv(),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("正常フロー: Access TokenをKVに保存してzaimUserIdを返す", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(storedState);
+
+    const res = await zaimRoutes.request(
+      "http://localhost/zaim/auth/callback?oauth_token=req_token_abc&oauth_verifier=verifier123",
+      {},
+      makeEnv(kv),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<{ ok: boolean; zaimUserId: string }>();
+    expect(body.ok).toBe(true);
+    expect(body.zaimUserId).toBe("zaim_user_999");
+  });
+
+  test("Access TokenをKVの zaim:token:{sub} に保存する", async () => {
+    const { kv, mockGet, mockPut } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(storedState);
+
+    await zaimRoutes.request(
+      "http://localhost/zaim/auth/callback?oauth_token=req_token_abc&oauth_verifier=verifier123",
+      {},
+      makeEnv(kv),
+    );
+
+    const [putKey, putVal] = mockPut.mock.calls[0] as [string, string];
+    expect(putKey).toBe("zaim:token:auth0|user123");
+    const saved = JSON.parse(putVal) as { oauthToken: string; zaimUserId: string };
+    expect(saved.oauthToken).toBe("access_token_abc");
+    expect(saved.zaimUserId).toBe("zaim_user_999");
+  });
+
+  test("Request TokenをKVから削除する", async () => {
+    const { kv, mockGet, mockDelete } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(storedState);
+
+    await zaimRoutes.request(
+      "http://localhost/zaim/auth/callback?oauth_token=req_token_abc&oauth_verifier=verifier123",
+      {},
+      makeEnv(kv),
+    );
+
+    expect(mockDelete).toHaveBeenCalledWith("zaim:request:req_token_abc");
+  });
+
+  test("拡張機能フロー: extRedirectUriへリダイレクトする", async () => {
+    const extUri = "https://abc.chromiumapp.org/callback";
+    const stateWithExt = JSON.stringify({
+      tokenSecret: "req_secret_xyz",
+      userSub: "auth0|user123",
+      extRedirectUri: extUri,
+    });
+
+    const { kv, mockGet } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(stateWithExt);
+
+    const res = await zaimRoutes.request(
+      "http://localhost/zaim/auth/callback?oauth_token=req_token_abc&oauth_verifier=verifier123",
+      {},
+      makeEnv(kv),
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(extUri);
+  });
+});
+
+// ── GET /zaim/auth/status ─────────────────────────────────────────────────────
+
+describe("GET /zaim/auth/status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuth.mockResolvedValue(MOCK_USER);
+  });
+
+  test("OIDC未認証のとき401を返す", async () => {
+    mockGetAuth.mockResolvedValueOnce(null);
+    const res = await zaimRoutes.request("http://localhost/zaim/auth/status", {}, makeEnv());
+    expect(res.status).toBe(401);
+  });
+
+  test("KVにトークンがない場合 connected: false を返す", async () => {
+    const res = await zaimRoutes.request("http://localhost/zaim/auth/status", {}, makeEnv());
+    expect(res.status).toBe(200);
+    const body = await res.json<{ connected: boolean }>();
+    expect(body.connected).toBe(false);
+  });
+
+  test("KVにトークンがある場合 connected: true とzaimUserIdを返す", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    const stored = JSON.stringify({
+      oauthToken: "access_token",
+      oauthTokenSecret: "access_secret",
+      zaimUserId: "zaim_user_999",
+    });
+    mockGet.mockResolvedValueOnce(stored);
+
+    const res = await zaimRoutes.request("http://localhost/zaim/auth/status", {}, makeEnv(kv));
+    expect(res.status).toBe(200);
+    const body = await res.json<{ connected: boolean; zaimUserId: string }>();
+    expect(body.connected).toBe(true);
+    expect(body.zaimUserId).toBe("zaim_user_999");
+  });
+
+  test("ユーザーのsubに対応するKVキーを参照する", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    await zaimRoutes.request("http://localhost/zaim/auth/status", {}, makeEnv(kv));
+    expect(mockGet).toHaveBeenCalledWith("zaim:token:auth0|user123");
+  });
+});
+
+// ── DELETE /zaim/auth/token ───────────────────────────────────────────────────
+
+describe("DELETE /zaim/auth/token", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuth.mockResolvedValue(MOCK_USER);
+  });
+
+  test("OIDC未認証のとき401を返す", async () => {
+    mockGetAuth.mockResolvedValueOnce(null);
+    const res = await zaimRoutes.request(
+      "http://localhost/zaim/auth/token",
+      { method: "DELETE" },
+      makeEnv(),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("KVからアクセストークンを削除して ok: true を返す", async () => {
+    const { kv, mockDelete } = createKVNamespaceMock();
+    const res = await zaimRoutes.request(
+      "http://localhost/zaim/auth/token",
+      { method: "DELETE" },
+      makeEnv(kv),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<{ ok: boolean }>();
+    expect(body.ok).toBe(true);
+    expect(mockDelete).toHaveBeenCalledWith("zaim:token:auth0|user123");
+  });
+});

--- a/apps/server/src/test-fixtures.ts
+++ b/apps/server/src/test-fixtures.ts
@@ -5,7 +5,8 @@
  * nonce・タイムスタンプをモックする test.extend フィクスチャを提供する。
  */
 
-import { test, vi } from "vite-plus/test";
+import { type MockedFunction, test, vi } from "vite-plus/test";
+import type { KVNamespace } from "@cloudflare/workers-types";
 
 /** RFC 5849 Appendix A.2 テストベクター */
 export const RFC = {
@@ -43,6 +44,42 @@ export interface OAuthTestFixtures {
   fixedTime: void;
   /** `crypto.randomUUID()` を RFC nonce に固定する */
   mockedNonce: void;
+}
+
+export interface KVNamespaceMock {
+  /** Cloudflare KV 互換オブジェクト（Env に渡す用） */
+  kv: KVNamespace;
+  /** get のモック関数（mockResolvedValueOnce などで制御する） */
+  mockGet: MockedFunction<(key: string) => Promise<string | null>>;
+  /** put のモック関数 */
+  mockPut: MockedFunction<(key: string, value: string) => Promise<void>>;
+  /** delete のモック関数 */
+  mockDelete: MockedFunction<(key: string) => Promise<void>>;
+}
+
+/**
+ * インメモリ KV ネームスペースモック
+ *
+ * get / put / delete のみ実装。TTL は無視する（テストでは期限切れを再現しない）。
+ * 返り値の mockGet / mockPut / mockDelete を使って挙動を制御する。
+ */
+export function createKVNamespaceMock(): KVNamespaceMock {
+  const store = new Map<string, string>();
+  const mockGet = vi.fn(async (key: string): Promise<string | null> => store.get(key) ?? null);
+  const mockPut = vi.fn(async (key: string, value: string): Promise<void> => {
+    store.set(key, value);
+  });
+  const mockDelete = vi.fn(async (key: string): Promise<void> => {
+    store.delete(key);
+  });
+  const kv = {
+    get: mockGet,
+    put: mockPut,
+    delete: mockDelete,
+    list: vi.fn(),
+    getWithMetadata: vi.fn(),
+  } as unknown as KVNamespace;
+  return { kv, mockGet, mockPut, mockDelete };
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage for three core route modules: authentication, Zaim OAuth integration, and category/genre management. A new KV namespace mock utility is also introduced to support testing Cloudflare Workers KV storage interactions.

## Key Changes

### New Test Files
- **`apps/server/src/routes/auth.test.ts`** (155 lines)
  - Tests for `/logout` endpoint (Auth0 logout flow, session revocation)
  - Tests for `/me` endpoint (authenticated user info retrieval)
  - Tests for `/auth/launch` endpoint (extension auth with redirect_uri validation)

- **`apps/server/src/routes/zaim.test.ts`** (309 lines)
  - Tests for `GET /zaim/auth/start` (OAuth request token flow, extension support)
  - Tests for `GET /zaim/auth/callback` (OAuth access token exchange, KV storage)
  - Tests for `GET /zaim/auth/status` (connection status check)
  - Tests for `DELETE /zaim/auth/token` (token revocation)
  - Covers both standard and extension-based OAuth flows with chromiumapp.org validation

- **`apps/server/src/routes/categories.test.ts`** (215 lines)
  - Tests for `GET /api/zaim/categories` (category and genre retrieval)
  - Tests for KV caching behavior (cache hits, misses, TTL)
  - Tests for genre nesting under categories
  - Tests for cache bypass with `no_cache=1` query parameter

### Updated Test Utilities
- **`apps/server/src/test-fixtures.ts`**
  - Added `KVNamespaceMock` interface for type-safe KV mocking
  - Added `createKVNamespaceMock()` function providing in-memory KV storage with mocked get/put/delete methods
  - Enables testing of KV-dependent features without external dependencies

## Notable Implementation Details

- All tests use `vi.mock()` to isolate external dependencies (@hono/oidc-auth, @repo/zaim-api)
- KV mock supports method chaining with `mockResolvedValueOnce()` for sequential test scenarios
- Tests validate both happy paths and error conditions (missing auth, invalid parameters, missing tokens)
- Extension flow tests verify chromiumapp.org domain validation for security
- Category tests verify proper nesting of genres under parent categories and cache key generation

https://claude.ai/code/session_01P8r4ovrpyT4xKwBeLq4E3Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive authentication route tests covering logout, user info, and auth-launch behaviors (redirects, error cases)
  * Added full OAuth integration tests for third‑party connection flows: start, callback, status, and token deletion scenarios
  * Added category endpoint tests covering cache hits/misses, API integration, TTL handling, and payload structure/validation
  * Added test utilities providing an in-memory KV mock for deterministic test behavior and control
<!-- end of auto-generated comment: release notes by coderabbit.ai -->