### PR TITLE
fix(extension): wxt dev コマンドの修正 - dev が root 引数として解釈される問題

### DIFF
--- a/apps/extension/vite.config.ts
+++ b/apps/extension/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   run: {
     tasks: {
       dev: {
-        command: "wxt dev",
+        command: "wxt",
         dependsOn: ["@repo/zaim-api#generate"],
       },
       build: {


### PR DESCRIPTION

## 概要

`vp run extension#dev` が失敗する問題を修正しました。

## 原因

WXT 0.20.25 の CLI では、デフォルトコマンドが `cli.command("[root]", "start dev server")` と定義されており、`wxt dev` を実行すると `dev` がコマンド名ではなく `[root]` 引数として解釈されます。これにより `root` が `apps/extension/dev` に設定され、エントリポイントが `apps/extension/dev/entrypoints`（存在しないディレクトリ）から検索されてエラーが発生していました。

## 修正内容

`apps/extension/vite.config.ts` の `extension#dev` タスクのコマンドを `wxt dev` から `wxt` に変更しました。
