### PR TITLE
feat: Zaimの支払い方法（口座）取得エンドポイントと表示機能を追加

### DIFF
--- a/apps/extension/.storybook/preview.ts
+++ b/apps/extension/.storybook/preview.ts
@@ -1,11 +1,19 @@
 import { definePreview } from "@storybook/react-vite";
 import { initialize, mswLoader } from "msw-storybook-addon";
+import { fakeBrowser } from "wxt/testing/fake-browser";
 
 import "../src/assets/global.css";
 
 initialize({
   onUnhandledRequest: "warn",
 });
+
+// wxt/browser はモジュールインポート時に globalThis.browser ?? globalThis.chrome を評価するため、
+// ストーリーのモジュールがロードされる前に設定しておく必要がある。
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).chrome = fakeBrowser;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).browser = fakeBrowser;
 
 export default definePreview({
   addons: [],

--- a/apps/extension/src/entrypoints/sidepanel/App.stories.tsx
+++ b/apps/extension/src/entrypoints/sidepanel/App.stories.tsx
@@ -1,4 +1,6 @@
 import { http, HttpResponse } from "msw";
+import { useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import preview from "../../../.storybook/preview";
 import { setupBrowserMock } from "../../test-utils/browser-mock.ts";
 import App from "./App.tsx";
@@ -9,6 +11,16 @@ const FIXED_FETCHED_AT = "2024-01-01T00:00:00.000Z";
 const meta = preview.meta({
   title: "Sidebar/App",
   component: App,
+  decorators: [
+    (Story) => {
+      const [queryClient] = useState(() => new QueryClient());
+      return (
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      );
+    },
+  ],
   loaders: [
     async (ctx) => {
       const serverUrl = (ctx.parameters.serverUrl as string | undefined) ?? MOCK_SERVER_URL;
@@ -99,6 +111,53 @@ export const FullyConnected = meta.story({
             ],
           }),
         ),
+        http.get(`${MOCK_SERVER_URL}/api/zaim/accounts`, () =>
+          HttpResponse.json({
+            fetchedAt: FIXED_FETCHED_AT,
+            accounts: [
+              {
+                id: 1,
+                name: "現金",
+                modified: "2024-01-01",
+                sort: 0,
+                active: 1,
+                localId: 0,
+                websiteId: 0,
+                parentAccountId: 0,
+              },
+              {
+                id: 2,
+                name: "クレジットカード",
+                modified: "2024-01-02",
+                sort: 1,
+                active: 1,
+                localId: 0,
+                websiteId: 0,
+                parentAccountId: 0,
+              },
+              {
+                id: 3,
+                name: "電子マネー",
+                modified: "2024-01-03",
+                sort: 2,
+                active: 1,
+                localId: 0,
+                websiteId: 0,
+                parentAccountId: 0,
+              },
+              {
+                id: 4,
+                name: "使わなくなった口座",
+                modified: "2024-01-04",
+                sort: 3,
+                active: 0,
+                localId: 0,
+                websiteId: 0,
+                parentAccountId: 0,
+              },
+            ],
+          }),
+        ),
       ],
     },
   },
@@ -128,6 +187,32 @@ export const CategoriesLoading = meta.story({
           // Never resolves to keep loading state visible indefinitely
           await new Promise<never>(() => {});
           return HttpResponse.json({ fetchedAt: "", categories: [] });
+        }),
+      ],
+    },
+  },
+});
+
+export const AccountsLoading = meta.story({
+  name: "口座読み込み中",
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(`${MOCK_SERVER_URL}/me`, () =>
+          HttpResponse.json({ email: "user@example.com", sub: "auth0|abc123" }),
+        ),
+        http.get(`${MOCK_SERVER_URL}/zaim/auth/status`, () =>
+          HttpResponse.json({ connected: true, zaimUserId: "zaim_user_123456" }),
+        ),
+        http.get(`${MOCK_SERVER_URL}/api/zaim/categories`, () =>
+          HttpResponse.json({
+            fetchedAt: FIXED_FETCHED_AT,
+            categories: [],
+          }),
+        ),
+        http.get(`${MOCK_SERVER_URL}/api/zaim/accounts`, async () => {
+          await new Promise<never>(() => {});
+          return HttpResponse.json({ fetchedAt: "", accounts: [] });
         }),
       ],
     },

--- a/apps/extension/src/entrypoints/sidepanel/App.tsx
+++ b/apps/extension/src/entrypoints/sidepanel/App.tsx
@@ -24,6 +24,17 @@ interface Category {
   subCategories: SubCategory[];
 }
 
+interface Account {
+  id: number;
+  name: string;
+  modified: string;
+  sort: number;
+  active: number;
+  localId: number;
+  websiteId: number;
+  parentAccountId: number;
+}
+
 interface AuthStatus {
   isServerAuthenticated: boolean;
   serverUser: ServerUser | null;
@@ -86,6 +97,18 @@ async function fetchCategoriesData(url: string) {
   throw new Error("カテゴリの取得に失敗しました");
 }
 
+async function fetchAccountsData(url: string) {
+  const client = createClient(url);
+  const res = await client.api.zaim.accounts.$get(
+    { query: {} },
+    { init: { credentials: "include", redirect: "manual" } },
+  );
+  if (res.ok && res.type !== "opaqueredirect") {
+    return res.json() as Promise<{ fetchedAt: string; accounts: Account[] }>;
+  }
+  throw new Error("口座の取得に失敗しました");
+}
+
 export default function App() {
   const queryClient = useQueryClient();
   const [serverUrlInput, setServerUrlInput] = useState("");
@@ -124,6 +147,16 @@ export default function App() {
     enabled: !!serverUrl && auth.isZaimConnected,
   });
 
+  const {
+    data: accountsData,
+    isFetching: accountsFetching,
+    error: accountsError,
+  } = useQuery({
+    queryKey: ["accounts", serverUrl],
+    queryFn: () => fetchAccountsData(serverUrl),
+    enabled: !!serverUrl && auth.isZaimConnected,
+  });
+
   const zaimConnectMutation = useMutation({
     mutationFn: () => launchZaimConnect(serverUrl),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["authStatus", serverUrl] }),
@@ -143,11 +176,14 @@ export default function App() {
     onSuccess: () => {
       queryClient.setQueryData(["authStatus", serverUrl], UNAUTHENTICATED);
       queryClient.removeQueries({ queryKey: ["categories", serverUrl] });
+      queryClient.removeQueries({ queryKey: ["accounts", serverUrl] });
     },
   });
 
   const categories = categoriesData?.categories ?? [];
   const categoriesFetchedAt = categoriesData?.fetchedAt ?? null;
+  const accounts = accountsData?.accounts ?? [];
+  const accountsFetchedAt = accountsData?.fetchedAt ?? null;
   const isLoading =
     authFetching || zaimConnectMutation.isPending || zaimDisconnectMutation.isPending;
   const errorMessage =
@@ -155,7 +191,8 @@ export default function App() {
     (authError instanceof Error ? authError.message : null) ??
     (zaimConnectMutation.error instanceof Error ? zaimConnectMutation.error.message : null) ??
     (zaimDisconnectMutation.error instanceof Error ? zaimDisconnectMutation.error.message : null) ??
-    (categoriesError instanceof Error ? categoriesError.message : null);
+    (categoriesError instanceof Error ? categoriesError.message : null) ??
+    (accountsError instanceof Error ? accountsError.message : null);
 
   async function handleSaveServerUrl() {
     const url = serverUrlInput.replace(/\/$/, "");
@@ -181,6 +218,7 @@ export default function App() {
     void browser.tabs.create({ url: `${serverUrl}/logout` });
     queryClient.setQueryData(["authStatus", serverUrl], UNAUTHENTICATED);
     queryClient.removeQueries({ queryKey: ["categories", serverUrl] });
+    queryClient.removeQueries({ queryKey: ["accounts", serverUrl] });
   }
 
   const paymentCategories = categories.filter((c) => c.mode === "payment");
@@ -269,6 +307,40 @@ export default function App() {
                             </li>
                           ))}
                         </ul>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          )}
+
+          {auth.isZaimConnected && (
+            <section className="flex flex-col gap-2">
+              <div className="flex items-baseline gap-2">
+                <label className="text-xs font-semibold text-gray-500">支払い方法</label>
+                {accountsFetchedAt && (
+                  <span className="text-xs text-gray-400">
+                    {new Date(accountsFetchedAt).toLocaleString("ja-JP")} 取得
+                  </span>
+                )}
+              </div>
+              {accountsFetching ? (
+                <p className="text-xs text-gray-400">読み込み中...</p>
+              ) : accounts.length === 0 ? (
+                <p className="text-xs text-gray-400">支払い方法がありません</p>
+              ) : (
+                <ul className="flex flex-col gap-1">
+                  {accounts.map((acc) => (
+                    <li
+                      key={acc.id}
+                      className="flex items-center justify-between rounded-md bg-white px-3 py-2 text-sm shadow-sm"
+                    >
+                      <span className="font-medium text-gray-800">{acc.name}</span>
+                      {acc.active === 0 && (
+                        <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-400">
+                          無効
+                        </span>
                       )}
                     </li>
                   ))}

--- a/apps/extension/src/test-utils/browser-mock.ts
+++ b/apps/extension/src/test-utils/browser-mock.ts
@@ -6,8 +6,11 @@ type BrowserMockOptions = {
 
 /**
  * Storybook 用 browser モックのセットアップ。
- * fakeBrowser を globalThis.chrome に設定し、storage の初期値を注入する。
+ * モックをリセットし、storage の初期値を注入する。
  * stories の loaders で await して呼び出すこと。
+ *
+ * NOTE: globalThis.chrome / globalThis.browser への fakeBrowser の割り当ては
+ *       .storybook/preview.ts で事前に行う（wxt/browser のモジュール評価タイミングに合わせるため）。
  */
 export async function setupBrowserMock({
   serverUrl = "http://mock-server.test",
@@ -21,10 +24,6 @@ export async function setupBrowserMock({
     getRedirectURL: (path?: string) => `https://mock.chromiumapp.org/${path ?? "redirect"}`,
     launchWebAuthFlow: () => Promise.resolve("https://mock.chromiumapp.org/redirect"),
   };
-
-  // @wxt-dev/browser は globalThis.browser が未設定の場合 globalThis.chrome にフォールバックするため、
-  // fakeBrowser を chrome グローバルとして登録することで wxt/browser の browser が fakeBrowser を指すようにする。
-  globalThis.chrome = fakeBrowser as unknown as typeof chrome;
 
   await fakeBrowser.storage.local.set({ serverUrl });
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -5,6 +5,7 @@ import { cors } from "hono/cors";
 import type { Env } from "./env.ts";
 import "./logger.ts";
 import { authRoutes } from "./routes/auth.ts";
+import { accountsRoutes } from "./routes/accounts.ts";
 import { categoriesRoutes } from "./routes/categories.ts";
 import { zaimRoutes } from "./routes/zaim.ts";
 
@@ -62,6 +63,7 @@ const app = base
   .route("/", zaimRoutes)
   // Zaim データ取得（/api/zaim/*）- /api/* の OIDC ミドルウェアで保護済み
   .route("/", categoriesRoutes)
+  .route("/", accountsRoutes)
   .route("/", healthRoute);
 
 export default app;

--- a/apps/server/src/logger.ts
+++ b/apps/server/src/logger.ts
@@ -18,3 +18,4 @@ export const authLogger = getLogger(["quick-zaim", "server", "auth"]);
 export const zaimOAuthLogger = getLogger(["quick-zaim", "server", "zaim-oauth"]);
 export const zaimRoutesLogger = getLogger(["quick-zaim", "server", "zaim-routes"]);
 export const categoriesLogger = getLogger(["quick-zaim", "server", "categories"]);
+export const accountsLogger = getLogger(["quick-zaim", "server", "accounts"]);

--- a/apps/server/src/routes/accounts.test.ts
+++ b/apps/server/src/routes/accounts.test.ts
@@ -1,0 +1,212 @@
+/**
+ * accounts ルートのテスト
+ *
+ * GET /api/zaim/accounts - 支払い方法（口座）一覧（KVキャッシュ付き）
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vite-plus/test";
+import { testClient } from "hono/testing";
+import { createKVNamespaceMock } from "../test-fixtures.ts";
+import { accountsRoutes } from "./accounts.ts";
+import type { Env } from "../env.ts";
+import type { KVNamespace } from "@cloudflare/workers-types";
+import type { OidcAuth } from "@hono/oidc-auth";
+
+vi.mock("@hono/oidc-auth", () => ({
+  getAuth: vi.fn(),
+  revokeSession: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { mockGetAccounts } = vi.hoisted(() => ({
+  mockGetAccounts: vi.fn(),
+}));
+
+vi.mock("@repo/zaim-api", () => ({
+  accountGetAccounts: mockGetAccounts,
+}));
+
+vi.mock("@repo/zaim-api/client", () => ({
+  createClient: vi.fn(() => ({
+    interceptors: { request: { use: vi.fn() } },
+  })),
+}));
+
+vi.mock("@repo/zaim-api/oauth/interceptor", () => ({
+  createZaimAuthInterceptor: vi.fn(() => () => {}),
+}));
+
+import { getAuth } from "@hono/oidc-auth";
+
+const mockGetAuth = vi.mocked(getAuth);
+
+const MOCK_USER = {
+  sub: "auth0|user123",
+  email: "user@example.com",
+  rtk: "",
+  rtkexp: 9999999999,
+  ssnexp: 9999999999,
+} as OidcAuth;
+
+const STORED_TOKEN = JSON.stringify({
+  oauthToken: "access_token",
+  oauthTokenSecret: "access_secret",
+  zaimUserId: "zaim_user_999",
+});
+
+const MOCK_ACCOUNTS_RESPONSE = {
+  accounts: [
+    {
+      id: 1,
+      name: "現金",
+      modified: "2026-01-01",
+      sort: 0,
+      active: 1,
+      local_id: 0,
+      website_id: 0,
+      parent_account_id: 0,
+    },
+    {
+      id: 2,
+      name: "クレジットカード",
+      modified: "2026-01-02",
+      sort: 1,
+      active: 1,
+      local_id: 0,
+      website_id: 0,
+      parent_account_id: 0,
+    },
+  ],
+};
+
+function makeEnv(kvOverride?: KVNamespace): Env {
+  const { kv } = createKVNamespaceMock();
+  return {
+    OIDC_ISSUER: "https://example.auth0.com/",
+    OIDC_CLIENT_ID: "test_client_id",
+    OIDC_CLIENT_SECRET: "test_client_secret",
+    OIDC_REDIRECT_URI: "https://example.com/callback",
+    OIDC_AUTH_SECRET: "test_auth_secret_32chars_minimum!",
+    ZAIM_CONSUMER_KEY: "zaim_consumer_key",
+    ZAIM_CONSUMER_SECRET: "zaim_consumer_secret",
+    ZAIM_KV: kvOverride ?? kv,
+  };
+}
+
+// ── GET /api/zaim/accounts ──────────────────────────────────────────────────
+
+describe("GET /api/zaim/accounts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuth.mockResolvedValue(MOCK_USER);
+    mockGetAccounts.mockResolvedValue({ data: MOCK_ACCOUNTS_RESPONSE });
+  });
+
+  test("OIDC未認証のとき401を返す", async () => {
+    mockGetAuth.mockResolvedValueOnce(null);
+    const res = await testClient(accountsRoutes, makeEnv()).api.zaim.accounts.$get({
+      query: {},
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("Zaimトークン未連携のとき403を返す", async () => {
+    const res = await testClient(accountsRoutes, makeEnv()).api.zaim.accounts.$get({
+      query: {},
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/Zaim/);
+  });
+
+  test("KVキャッシュヒット時はZaim APIを呼ばずにキャッシュを返す", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    const cachedData = {
+      fetchedAt: "2026-01-01T00:00:00.000Z",
+      accounts: [{ id: 1, name: "現金" }],
+    };
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(JSON.stringify(cachedData));
+
+    const res = await testClient(accountsRoutes, makeEnv(kv)).api.zaim.accounts.$get({
+      query: {},
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as typeof cachedData;
+    expect(body.fetchedAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(mockGetAccounts).not.toHaveBeenCalled();
+  });
+
+  test("キャッシュミス時はZaim APIを呼んで口座一覧を返す", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
+
+    const res = await testClient(accountsRoutes, makeEnv(kv)).api.zaim.accounts.$get({
+      query: {},
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { fetchedAt: string; accounts: unknown[] };
+    expect(body.accounts).toHaveLength(2);
+    expect(mockGetAccounts).toHaveBeenCalledOnce();
+  });
+
+  test("口座取得後にKVへキャッシュを書き込む", async () => {
+    const { kv, mockGet, mockPut } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
+
+    await testClient(accountsRoutes, makeEnv(kv)).api.zaim.accounts.$get({ query: {} });
+
+    expect(mockPut).toHaveBeenCalledWith("zaim:cache:accounts:zaim_user_999", expect.any(String), {
+      expirationTtl: 86400,
+    });
+  });
+
+  test("no_cache=1のときKVキャッシュを無視してAPIを呼ぶ", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    const cachedData = { fetchedAt: "2026-01-01T00:00:00.000Z", accounts: [] };
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(JSON.stringify(cachedData));
+
+    const res = await testClient(accountsRoutes, makeEnv(kv)).api.zaim.accounts.$get({
+      query: { no_cache: "1" },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { accounts: unknown[] };
+    expect(body.accounts).toHaveLength(2);
+    expect(mockGetAccounts).toHaveBeenCalledOnce();
+  });
+
+  test("レスポンスにfetchedAt（ISO 8601）が含まれる", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
+
+    const res = await testClient(accountsRoutes, makeEnv(kv)).api.zaim.accounts.$get({
+      query: {},
+    });
+    const body = (await res.json()) as { fetchedAt: string };
+    expect(() => new Date(body.fetchedAt)).not.toThrow();
+    expect(body.fetchedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test("口座フィールドが正しくマッピングされる", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
+
+    const res = await testClient(accountsRoutes, makeEnv(kv)).api.zaim.accounts.$get({
+      query: {},
+    });
+    const body = (await res.json()) as {
+      accounts: {
+        id: number;
+        name: string;
+        localId: number;
+        websiteId: number;
+        parentAccountId: number;
+      }[];
+    };
+
+    const acc = body.accounts[0];
+    expect(acc.id).toBe(1);
+    expect(acc.name).toBe("現金");
+    expect(acc.localId).toBe(0);
+    expect(acc.websiteId).toBe(0);
+    expect(acc.parentAccountId).toBe(0);
+  });
+});

--- a/apps/server/src/routes/accounts.ts
+++ b/apps/server/src/routes/accounts.ts
@@ -1,0 +1,144 @@
+/**
+ * Zaim 支払い方法（口座）取得ルート（KV キャッシュ付き）
+ *
+ * エンドポイント:
+ *   GET /api/zaim/accounts - 支払い方法（口座）の一覧を返す
+ *
+ * KV キー設計:
+ *   zaim:cache:accounts:{zaim_user_id} - 口座キャッシュ（TTL 1日）
+ */
+
+import { accountGetAccounts } from "@repo/zaim-api";
+import { createClient } from "@repo/zaim-api/client";
+import { sValidator } from "@hono/standard-validator";
+import { getAuth } from "@hono/oidc-auth";
+import { Hono } from "hono";
+import * as v from "valibot";
+import type { Env } from "../env.ts";
+import { getStoredZaimToken } from "./zaim.ts";
+import { createZaimAuthInterceptor } from "@repo/zaim-api/oauth/interceptor";
+import type { OAuth1Config } from "@repo/zaim-api/oauth/oauth1";
+import { accountsLogger } from "../logger.ts";
+
+const AccountsQuerySchema = v.object({
+  no_cache: v.optional(v.string()),
+});
+
+const ZAIM_API_BASE = "https://api.zaim.net";
+const CACHE_TTL = 86400;
+
+export type Account = {
+  id: number;
+  name: string;
+  modified: string;
+  sort: number;
+  active: number;
+  localId: number;
+  websiteId: number;
+  parentAccountId: number;
+};
+
+export type AccountsResponse = {
+  /** Zaim API からデータを取得した日時（ISO 8601） */
+  fetchedAt: string;
+  accounts: Account[];
+};
+
+async function fetchAccountsFromZaim(oauthConfig: OAuth1Config): Promise<AccountsResponse> {
+  const client = createClient({ baseUrl: ZAIM_API_BASE });
+  client.interceptors.request.use(createZaimAuthInterceptor(oauthConfig));
+
+  accountsLogger.debug("Fetching accounts from Zaim API");
+
+  const result = await accountGetAccounts({
+    client,
+    query: { mapping: 1 },
+  });
+
+  if (!result.data) {
+    accountsLogger.error("Failed to fetch accounts from Zaim API");
+    throw new Error("Failed to fetch accounts from Zaim API");
+  }
+
+  const accountCount = result.data.accounts.length;
+  accountsLogger.with({ accountCount }).debug("Zaim API returned {accountCount} accounts");
+
+  return {
+    fetchedAt: new Date().toISOString(),
+    accounts: result.data.accounts.map((account) => ({
+      id: account.id,
+      name: account.name,
+      modified: account.modified,
+      sort: account.sort,
+      active: account.active,
+      localId: account.local_id,
+      websiteId: account.website_id,
+      parentAccountId: account.parent_account_id,
+    })),
+  };
+}
+
+/**
+ * 支払い方法（口座）一覧取得
+ *
+ * Zaim API から口座一覧を取得し、KV に 1 日間キャッシュする。
+ */
+const getAccountsRoute = new Hono<{ Bindings: Env }>().get(
+  "/api/zaim/accounts",
+  sValidator("query", AccountsQuerySchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ error: "Invalid query parameters" }, 400);
+    }
+  }),
+  async (c) => {
+    const auth = await getAuth(c);
+    if (!auth?.sub) {
+      accountsLogger.warn("Accounts: unauthorized (no OIDC session)");
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    const token = await getStoredZaimToken(c.env.ZAIM_KV, auth.sub);
+    if (!token) {
+      accountsLogger.with({ userSub: auth.sub }).warn("Accounts: Zaim not connected for {userSub}");
+      return c.json({ error: "Zaim not connected" }, 403);
+    }
+
+    const { no_cache: noCache } = c.req.valid("query");
+    const cacheKey = `zaim:cache:accounts:${token.zaimUserId}`;
+
+    if (noCache !== "1") {
+      const cached = await c.env.ZAIM_KV.get(cacheKey);
+      if (cached) {
+        accountsLogger
+          .with({ zaimUserId: token.zaimUserId })
+          .debug("Accounts cache hit for Zaim user {zaimUserId}");
+        return c.json(JSON.parse(cached) as AccountsResponse);
+      }
+      accountsLogger
+        .with({ zaimUserId: token.zaimUserId })
+        .debug("Accounts cache miss for Zaim user {zaimUserId}, fetching from API");
+    } else {
+      accountsLogger
+        .with({ zaimUserId: token.zaimUserId })
+        .debug("Accounts cache bypassed (no_cache=1) for Zaim user {zaimUserId}");
+    }
+
+    const oauthConfig: OAuth1Config = {
+      consumerKey: c.env.ZAIM_CONSUMER_KEY,
+      consumerSecret: c.env.ZAIM_CONSUMER_SECRET,
+      token: token.oauthToken,
+      tokenSecret: token.oauthTokenSecret,
+    };
+
+    const result = await fetchAccountsFromZaim(oauthConfig);
+
+    await c.env.ZAIM_KV.put(cacheKey, JSON.stringify(result), { expirationTtl: CACHE_TTL });
+    accountsLogger
+      .with({ zaimUserId: token.zaimUserId, ttl: CACHE_TTL })
+      .debug("Accounts cached for Zaim user {zaimUserId} (TTL={ttl}s)");
+
+    return c.json(result);
+  },
+);
+
+export const accountsRoutes = new Hono<{ Bindings: Env }>().route("/", getAccountsRoute);


### PR DESCRIPTION

## Summary

- Zaim APIから支払い方法（口座）を取得する `GET /api/zaim/accounts` エンドポイントを追加（KVキャッシュ付き）
- 拡張機能のサイドパネルに口座一覧を表示するUIを追加
- Storybookの `QueryClientProvider` / browser mock 設定を修正

## Changes

### Server (`apps/server`)

- `GET /api/zaim/accounts` エンドポイントを追加（`routes/accounts.ts`）
  - `valibot` + `sValidator` によるクエリバリデーション
  - OIDC認証 / Zaimトークン確認
  - KVキャッシュ（TTL 1日、`no_cache=1` でバイパス可能）
- テストを追加（`routes/accounts.test.ts`、8件）
- `index.ts` にルート登録、`logger.ts` に `accountsLogger` 追加

### Extension (`apps/extension`)

- 口座一覧の取得・表示UIを `App.tsx` に追加
  - `useQuery(["accounts", serverUrl])` でデータ取得
  - 口座名と有効/無効ステータスを表示
  - 切断・ログアウト時にキャッシュクリア

### Storybook

- `QueryClientProvider` デコレータを追加（`App.stories.tsx`）
- `FullyConnected` に accounts MSWハンドラを追加
- `AccountsLoading` ストーリーを追加
- `.storybook/preview.ts` で `fakeBrowser` をグローバルに事前設定（`wxt/browser` のモジュール評価タイミング対応）
