### PR TITLE
"feat(zaim-api): OAuth エンドポイントを TypeSpec 定義に移行し、生成 SDK 対応"

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "typescript/no-non-null-assertion": "error"
+  }
+}

--- a/apps/server/src/zaim-oauth.test.ts
+++ b/apps/server/src/zaim-oauth.test.ts
@@ -1,89 +1,33 @@
 /**
- * Zaim 固有 OAuth 1.0a ヘルパー (zaim-oauth.ts) のテスト
+ * Zaim 固有 OAuth 1.0a ヘルパー (zaim-oauth.ts) のサーバー依存 fetch ロジックのテスト
+ *
+ * 純粋関数 (buildZaimAuthorizeUrl, buildZaimApiAuthHeader) は
+ * @repo/zaim-api 側でテスト済みのため、ここでは SDK 呼び出しを伴う関数のみテストする。
  */
 
-import { describe, expect, test, vi } from "vite-plus/test";
-import {
-  buildZaimApiAuthHeader,
-  buildZaimAuthorizeUrl,
-  fetchZaimAccessToken,
-  fetchZaimRequestToken,
-} from "./zaim-oauth.ts";
-import { oauthTest, parseOAuthHeader, RFC, type OAuthTestFixtures } from "./test-fixtures.ts";
+import { beforeEach, describe, expect, vi } from "vite-plus/test";
+import { fetchZaimAccessToken, fetchZaimRequestToken } from "./zaim-oauth.ts";
+import { oauthTest, parseOAuthHeader } from "./test-fixtures.ts";
 
-// ── fetch モック付き拡張 test ────────────────────────────────────────────────
-
-interface MockFetchFixtures extends OAuthTestFixtures {
-  mockFetch: ReturnType<typeof vi.fn>;
-}
-
-const zaimTest = oauthTest.extend<Pick<MockFetchFixtures, "mockFetch">>({
-  // eslint-disable-next-line no-empty-pattern
-  mockFetch: async ({}, use: (value: ReturnType<typeof vi.fn>) => Promise<void>) => {
-    const mock = vi.fn();
-    vi.stubGlobal("fetch", mock);
-    await use(mock);
-    vi.unstubAllGlobals();
-  },
+beforeEach(() => {
+  vi.clearAllMocks();
 });
 
-// ── buildZaimAuthorizeUrl ────────────────────────────────────────────────────
+const { mockAuthRequestToken, mockAuthAccessToken } = vi.hoisted(() => ({
+  mockAuthRequestToken: vi.fn(),
+  mockAuthAccessToken: vi.fn(),
+}));
 
-describe("buildZaimAuthorizeUrl", () => {
-  test("認可URLにoauth_tokenクエリパラメータを付与する", () => {
-    expect(buildZaimAuthorizeUrl("mytoken123")).toBe(
-      "https://auth.zaim.net/users/auth?oauth_token=mytoken123",
-    );
-  });
+vi.mock("@repo/zaim-api", () => ({
+  authRequestToken: mockAuthRequestToken,
+  authAccessToken: mockAuthAccessToken,
+}));
 
-  test("oauth_tokenに含まれる特殊文字をパーセントエンコードする", () => {
-    expect(buildZaimAuthorizeUrl("token+with/special=chars")).toBe(
-      "https://auth.zaim.net/users/auth?oauth_token=token%2Bwith%2Fspecial%3Dchars",
-    );
-  });
-});
-
-// ── buildZaimApiAuthHeader ───────────────────────────────────────────────────
-
-describe("buildZaimApiAuthHeader", () => {
-  oauthTest(
-    "RFC 5849 Appendix A.2 テストベクターと一致する署名を生成する",
-    async ({ fixedTime: _t, mockedNonce: _n }) => {
-      const header = await buildZaimApiAuthHeader(
-        {
-          consumerKey: RFC.consumerKey,
-          consumerSecret: RFC.consumerSecret,
-          token: RFC.token,
-          tokenSecret: RFC.tokenSecret,
-        },
-        RFC.method,
-        RFC.url,
-        RFC.queryParams,
-      );
-      expect(parseOAuthHeader(header).oauth_signature).toBe(RFC.expectedSignature);
-    },
-  );
-
-  oauthTest(
-    "クエリパラメータが異なれば署名も異なる",
-    async ({ fixedTime: _t, mockedNonce: _n }) => {
-      const withParams = await buildZaimApiAuthHeader(
-        { consumerKey: "key", consumerSecret: "secret" },
-        "GET",
-        "https://api.zaim.net/v2/home/money",
-        { mode: "payment" },
-      );
-      const withoutParams = await buildZaimApiAuthHeader(
-        { consumerKey: "key", consumerSecret: "secret" },
-        "GET",
-        "https://api.zaim.net/v2/home/money",
-      );
-      expect(parseOAuthHeader(withParams).oauth_signature).not.toBe(
-        parseOAuthHeader(withoutParams).oauth_signature,
-      );
-    },
-  );
-});
+vi.mock("@repo/zaim-api/client", () => ({
+  createClient: vi.fn(() => ({
+    interceptors: { request: { use: vi.fn() } },
+  })),
+}));
 
 // ── fetchZaimRequestToken ────────────────────────────────────────────────────
 
@@ -91,73 +35,83 @@ describe("fetchZaimRequestToken", () => {
   const SUCCESS_BODY =
     "oauth_token=req_token&oauth_token_secret=req_secret&oauth_callback_confirmed=true";
 
-  zaimTest(
+  oauthTest(
     "ZaimのRequest Token エンドポイントにPOSTする",
-    async ({ fixedTime: _t, mockedNonce: _n, mockFetch }) => {
-      mockFetch.mockResolvedValue(new Response(SUCCESS_BODY));
+    async ({ fixedTime: _t, mockedNonce: _n }) => {
+      mockAuthRequestToken.mockResolvedValue({
+        data: SUCCESS_BODY,
+        response: new Response(SUCCESS_BODY),
+      });
 
       await fetchZaimRequestToken(
         { consumerKey: "key", consumerSecret: "secret" },
         "https://example.com/callback",
       );
 
-      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
-      expect(url).toBe("https://api.zaim.net/v2/auth/request");
-      expect(init.method).toBe("POST");
+      expect(mockAuthRequestToken).toHaveBeenCalled();
     },
   );
 
-  zaimTest(
+  oauthTest(
     "AuthorizationヘッダーにOAuth 1.0aパラメータを含む",
-    async ({ fixedTime: _t, mockedNonce: _n, mockFetch }) => {
-      mockFetch.mockResolvedValue(new Response(SUCCESS_BODY));
+    async ({ fixedTime: _t, mockedNonce: _n }) => {
+      mockAuthRequestToken.mockResolvedValue({
+        data: SUCCESS_BODY,
+        response: new Response(SUCCESS_BODY),
+      });
 
       await fetchZaimRequestToken(
         { consumerKey: "mykey", consumerSecret: "mysecret" },
         "https://example.com/callback",
       );
 
-      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
-      const params = parseOAuthHeader((init.headers as Record<string, string>).Authorization);
+      const options = mockAuthRequestToken.mock.calls[0][0];
+      const params = parseOAuthHeader(options.headers.Authorization as string);
       expect(params.oauth_consumer_key).toBe("mykey");
       expect(params.oauth_signature_method).toBe("HMAC-SHA1");
       expect(params.oauth_version).toBe("1.0");
     },
   );
 
-  zaimTest(
+  oauthTest(
     "AuthorizationヘッダーにURLエンコードされたoauth_callbackを含む",
-    async ({ fixedTime: _t, mockedNonce: _n, mockFetch }) => {
-      mockFetch.mockResolvedValue(new Response(SUCCESS_BODY));
+    async ({ fixedTime: _t, mockedNonce: _n }) => {
+      mockAuthRequestToken.mockResolvedValue({
+        data: SUCCESS_BODY,
+        response: new Response(SUCCESS_BODY),
+      });
 
       await fetchZaimRequestToken(
         { consumerKey: "key", consumerSecret: "secret" },
         "https://example.com/callback?foo=bar",
       );
 
-      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
-      const params = parseOAuthHeader((init.headers as Record<string, string>).Authorization);
+      const options = mockAuthRequestToken.mock.calls[0][0];
+      const params = parseOAuthHeader(options.headers.Authorization as string);
       expect(params.oauth_callback).toBe("https://example.com/callback?foo=bar");
     },
   );
 
-  zaimTest(
-    "oauthTokenとoauthTokenSecretを返す",
-    async ({ fixedTime: _t, mockedNonce: _n, mockFetch }) => {
-      mockFetch.mockResolvedValue(new Response(SUCCESS_BODY));
+  oauthTest("oauthTokenとoauthTokenSecretを返す", async ({ fixedTime: _t, mockedNonce: _n }) => {
+    mockAuthRequestToken.mockResolvedValue({
+      data: SUCCESS_BODY,
+      response: new Response(SUCCESS_BODY),
+    });
 
-      const result = await fetchZaimRequestToken(
-        { consumerKey: "key", consumerSecret: "secret" },
-        "https://example.com/callback",
-      );
-      expect(result).toEqual({ oauthToken: "req_token", oauthTokenSecret: "req_secret" });
-    },
-  );
+    const result = await fetchZaimRequestToken(
+      { consumerKey: "key", consumerSecret: "secret" },
+      "https://example.com/callback",
+    );
+    expect(result).toEqual({ oauthToken: "req_token", oauthTokenSecret: "req_secret" });
+  });
 
-  zaimTest(
+  oauthTest(
     "HTTPエラーレスポンス時にエラーをスローする",
-    async ({ fixedTime: _t, mockedNonce: _n, mockFetch }) => {
-      mockFetch.mockResolvedValue(new Response("Unauthorized", { status: 401 }));
+    async ({ fixedTime: _t, mockedNonce: _n }) => {
+      mockAuthRequestToken.mockResolvedValue({
+        error: "Unauthorized",
+        response: new Response("Unauthorized", { status: 401 }),
+      });
 
       await expect(
         fetchZaimRequestToken(
@@ -168,10 +122,13 @@ describe("fetchZaimRequestToken", () => {
     },
   );
 
-  zaimTest(
+  oauthTest(
     "レスポンスにoauth_tokenが欠ける場合にエラーをスローする",
-    async ({ fixedTime: _t, mockedNonce: _n, mockFetch }) => {
-      mockFetch.mockResolvedValue(new Response("oauth_token_secret=only_secret"));
+    async ({ fixedTime: _t, mockedNonce: _n }) => {
+      mockAuthRequestToken.mockResolvedValue({
+        data: "oauth_token_secret=only_secret",
+        response: new Response("oauth_token_secret=only_secret"),
+      });
 
       await expect(
         fetchZaimRequestToken(
@@ -195,37 +152,44 @@ describe("fetchZaimAccessToken", () => {
     tokenSecret: "req_secret",
   };
 
-  zaimTest(
+  oauthTest(
     "ZaimのAccess Token エンドポイントにPOSTする",
-    async ({ fixedTime: _t, mockedNonce: _n, mockFetch }) => {
-      mockFetch.mockResolvedValue(new Response(SUCCESS_BODY));
+    async ({ fixedTime: _t, mockedNonce: _n }) => {
+      mockAuthAccessToken.mockResolvedValue({
+        data: SUCCESS_BODY,
+        response: new Response(SUCCESS_BODY),
+      });
 
       await fetchZaimAccessToken(REQ_CONFIG, "verifier123");
 
-      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
-      expect(url).toBe("https://api.zaim.net/v2/auth/access");
-      expect(init.method).toBe("POST");
+      expect(mockAuthAccessToken).toHaveBeenCalled();
     },
   );
 
-  zaimTest(
+  oauthTest(
     "AuthorizationヘッダーにRequest TokenとVerifierを含む",
-    async ({ fixedTime: _t, mockedNonce: _n, mockFetch }) => {
-      mockFetch.mockResolvedValue(new Response(SUCCESS_BODY));
+    async ({ fixedTime: _t, mockedNonce: _n }) => {
+      mockAuthAccessToken.mockResolvedValue({
+        data: SUCCESS_BODY,
+        response: new Response(SUCCESS_BODY),
+      });
 
       await fetchZaimAccessToken(REQ_CONFIG, "myverifier");
 
-      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
-      const params = parseOAuthHeader((init.headers as Record<string, string>).Authorization);
+      const options = mockAuthAccessToken.mock.calls[0][0];
+      const params = parseOAuthHeader(options.headers.Authorization as string);
       expect(params.oauth_token).toBe("req_token");
       expect(params.oauth_verifier).toBe("myverifier");
     },
   );
 
-  zaimTest(
+  oauthTest(
     "oauthToken・oauthTokenSecret・userIdを返す",
-    async ({ fixedTime: _t, mockedNonce: _n, mockFetch }) => {
-      mockFetch.mockResolvedValue(new Response(SUCCESS_BODY));
+    async ({ fixedTime: _t, mockedNonce: _n }) => {
+      mockAuthAccessToken.mockResolvedValue({
+        data: SUCCESS_BODY,
+        response: new Response(SUCCESS_BODY),
+      });
 
       const result = await fetchZaimAccessToken(REQ_CONFIG, "verifier");
       expect(result).toEqual({
@@ -235,10 +199,13 @@ describe("fetchZaimAccessToken", () => {
     },
   );
 
-  zaimTest(
+  oauthTest(
     "HTTPエラーレスポンス時にエラーをスローする",
-    async ({ fixedTime: _t, mockedNonce: _n, mockFetch }) => {
-      mockFetch.mockResolvedValue(new Response("Bad Request", { status: 400 }));
+    async ({ fixedTime: _t, mockedNonce: _n }) => {
+      mockAuthAccessToken.mockResolvedValue({
+        error: "Bad Request",
+        response: new Response("Bad Request", { status: 400 }),
+      });
 
       await expect(fetchZaimAccessToken(REQ_CONFIG, "verifier")).rejects.toThrow(
         "Access token failed [400]",
@@ -246,10 +213,13 @@ describe("fetchZaimAccessToken", () => {
     },
   );
 
-  zaimTest(
+  oauthTest(
     "oauth_tokenが欠ける場合にエラーをスローする",
-    async ({ fixedTime: _t, mockedNonce: _n, mockFetch }) => {
-      mockFetch.mockResolvedValue(new Response("oauth_token_secret=sec"));
+    async ({ fixedTime: _t, mockedNonce: _n }) => {
+      mockAuthAccessToken.mockResolvedValue({
+        data: "oauth_token_secret=sec",
+        response: new Response("oauth_token_secret=sec"),
+      });
 
       await expect(fetchZaimAccessToken(REQ_CONFIG, "verifier")).rejects.toThrow();
     },

--- a/apps/server/src/zaim-oauth.ts
+++ b/apps/server/src/zaim-oauth.ts
@@ -11,14 +11,19 @@
  *   4. ユーザー ID 取得: GET https://api.zaim.net/v2/home/user/verify
  */
 
+import { authAccessToken, authRequestToken, userVerifyUser } from "@repo/zaim-api";
+import { createClient } from "@repo/zaim-api/client";
+import { createZaimAuthInterceptor } from "@repo/zaim-api/oauth/interceptor";
 import { type OAuth1Config, buildOAuth1AuthorizationHeader } from "@repo/zaim-api/oauth/oauth1";
+import type { AccessTokenResult, RequestTokenResult } from "@repo/zaim-api/oauth/zaim-oauth";
 import * as v from "valibot";
 import { zaimOAuthLogger } from "./logger.ts";
 
-const ZAIM_REQUEST_TOKEN_URL = "https://api.zaim.net/v2/auth/request";
-const ZAIM_AUTHORIZE_URL = "https://auth.zaim.net/users/auth";
-const ZAIM_ACCESS_TOKEN_URL = "https://api.zaim.net/v2/auth/access";
-const ZAIM_USER_VERIFY_URL = "https://api.zaim.net/v2/home/user/verify";
+export { buildZaimApiAuthHeader, buildZaimAuthorizeUrl } from "@repo/zaim-api/oauth/zaim-oauth";
+export type { AccessTokenResult, RequestTokenResult } from "@repo/zaim-api/oauth/zaim-oauth";
+
+const ZAIM_API_BASE = "https://api.zaim.net";
+const zaimClient = createClient({ baseUrl: ZAIM_API_BASE });
 
 const RequestTokenSchema = v.object({
   oauth_token: v.string(),
@@ -36,16 +41,6 @@ const UserVerifySchema = v.object({
   }),
 });
 
-export interface RequestTokenResult {
-  oauthToken: string;
-  oauthTokenSecret: string;
-}
-
-export interface AccessTokenResult {
-  oauthToken: string;
-  oauthTokenSecret: string;
-}
-
 /**
  * Zaim から Request Token を取得する
  * @param config      - Consumer Key / Secret
@@ -55,45 +50,32 @@ export async function fetchZaimRequestToken(
   config: OAuth1Config,
   callbackUrl: string,
 ): Promise<RequestTokenResult> {
-  const authHeader = await buildOAuth1AuthorizationHeader("POST", ZAIM_REQUEST_TOKEN_URL, config, {
+  const requestUrl = `${ZAIM_API_BASE}/v2/auth/request`;
+  const authHeader = await buildOAuth1AuthorizationHeader("POST", requestUrl, config, {
     oauth_callback: callbackUrl,
   });
 
-  zaimOAuthLogger
-    .with({ url: ZAIM_REQUEST_TOKEN_URL, callbackUrl })
-    .debug("Fetching Zaim request token");
+  zaimOAuthLogger.with({ url: requestUrl, callbackUrl }).debug("Fetching Zaim request token");
 
-  const response = await fetch(ZAIM_REQUEST_TOKEN_URL, {
-    method: "POST",
-    headers: {
-      Authorization: authHeader,
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
+  const { data, error, response } = await authRequestToken({
+    client: zaimClient,
+    headers: { Authorization: authHeader },
   });
 
-  if (!response.ok) {
-    const body = await response.text();
+  if (error) {
     zaimOAuthLogger
-      .with({ status: response.status, body })
+      .with({ status: response.status, body: error })
       .error("Zaim request token fetch failed [{status}]: {body}");
-    throw new Error(`Request token failed [${response.status}]: ${body}`);
+    throw new Error(`Request token failed [${response.status}]: ${error}`);
   }
 
-  const parsed = v.parse(
-    RequestTokenSchema,
-    Object.fromEntries(new URLSearchParams(await response.text())),
-  );
+  const parsed = v.parse(RequestTokenSchema, Object.fromEntries(new URLSearchParams(data!)));
 
   zaimOAuthLogger
     .with({ oauthToken: parsed.oauth_token })
     .debug("Zaim request token obtained: {oauthToken}");
 
   return { oauthToken: parsed.oauth_token, oauthTokenSecret: parsed.oauth_token_secret };
-}
-
-/** Zaim ユーザー認可 URL を構築する */
-export function buildZaimAuthorizeUrl(oauthToken: string): string {
-  return `${ZAIM_AUTHORIZE_URL}?oauth_token=${encodeURIComponent(oauthToken)}`;
 }
 
 /**
@@ -109,32 +91,26 @@ export async function fetchZaimAccessToken(
   config: OAuth1Config,
   oauthVerifier: string,
 ): Promise<AccessTokenResult> {
-  const authHeader = await buildOAuth1AuthorizationHeader("POST", ZAIM_ACCESS_TOKEN_URL, config, {
+  const accessUrl = `${ZAIM_API_BASE}/v2/auth/access`;
+  const authHeader = await buildOAuth1AuthorizationHeader("POST", accessUrl, config, {
     oauth_verifier: oauthVerifier,
   });
 
-  zaimOAuthLogger.with({ url: ZAIM_ACCESS_TOKEN_URL }).debug("Fetching Zaim access token");
+  zaimOAuthLogger.with({ url: accessUrl }).debug("Fetching Zaim access token");
 
-  const response = await fetch(ZAIM_ACCESS_TOKEN_URL, {
-    method: "POST",
-    headers: {
-      Authorization: authHeader,
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
+  const { data, error, response } = await authAccessToken({
+    client: zaimClient,
+    headers: { Authorization: authHeader },
   });
 
-  if (!response.ok) {
-    const body = await response.text();
+  if (error || !data) {
     zaimOAuthLogger
-      .with({ status: response.status, body })
+      .with({ status: response.status, body: error })
       .error("Zaim access token fetch failed [{status}]: {body}");
-    throw new Error(`Access token failed [${response.status}]: ${body}`);
+    throw new Error(`Access token failed [${response.status}]: ${error}`);
   }
 
-  const parsed = v.parse(
-    AccessTokenSchema,
-    Object.fromEntries(new URLSearchParams(await response.text())),
-  );
+  const parsed = v.parse(AccessTokenSchema, Object.fromEntries(new URLSearchParams(data)));
 
   zaimOAuthLogger.debug("Zaim access token obtained");
 
@@ -146,42 +122,26 @@ export async function fetchZaimAccessToken(
  * @param config - Consumer Key / Secret + Access Token / Secret
  */
 export async function fetchZaimUserId(config: OAuth1Config): Promise<string> {
-  const authHeader = await buildOAuth1AuthorizationHeader("GET", ZAIM_USER_VERIFY_URL, config);
+  const client = createClient({ baseUrl: ZAIM_API_BASE });
+  client.interceptors.request.use(createZaimAuthInterceptor(config));
 
-  zaimOAuthLogger.with({ url: ZAIM_USER_VERIFY_URL }).debug("Fetching Zaim user ID");
+  zaimOAuthLogger.debug("Fetching Zaim user ID");
 
-  const response = await fetch(ZAIM_USER_VERIFY_URL, {
-    headers: { Authorization: authHeader },
-  });
+  const { data, error, response } = await userVerifyUser({ client });
 
-  if (!response.ok) {
-    const body = await response.text();
+  if (error || !data) {
     zaimOAuthLogger
-      .with({ status: response.status, body })
+      .with({ status: response.status, body: error })
       .error("Zaim user verify failed [{status}]: {body}");
-    throw new Error(`User verify failed [${response.status}]: ${body}`);
+    throw new Error(
+      `User verify failed [${response.status}]: ${error?.message ?? JSON.stringify(error)}`,
+    );
   }
 
-  const parsed = v.parse(UserVerifySchema, await response.json());
+  const parsed = v.parse(UserVerifySchema, data);
   const userId = String(parsed.me.id);
 
   zaimOAuthLogger.with({ zaimUserId: userId }).debug("Zaim user ID obtained: {zaimUserId}");
 
   return userId;
-}
-
-/**
- * 保存済みアクセストークンを使って Zaim API リクエスト用の Authorization ヘッダーを生成する
- * @param config      - Consumer Key / Secret + Access Token / Secret
- * @param method      - HTTP メソッド
- * @param url         - クエリ文字列を含まないリクエスト URL
- * @param queryParams - 署名対象のクエリパラメータ
- */
-export async function buildZaimApiAuthHeader(
-  config: OAuth1Config,
-  method: string,
-  url: string,
-  queryParams: Record<string, string> = {},
-): Promise<string> {
-  return buildOAuth1AuthorizationHeader(method, url, config, {}, queryParams);
 }

--- a/apps/server/src/zaim-oauth.ts
+++ b/apps/server/src/zaim-oauth.ts
@@ -62,14 +62,14 @@ export async function fetchZaimRequestToken(
     headers: { Authorization: authHeader },
   });
 
-  if (error) {
+  if (error || !data) {
     zaimOAuthLogger
       .with({ status: response.status, body: error })
       .error("Zaim request token fetch failed [{status}]: {body}");
     throw new Error(`Request token failed [${response.status}]: ${error}`);
   }
 
-  const parsed = v.parse(RequestTokenSchema, Object.fromEntries(new URLSearchParams(data!)));
+  const parsed = v.parse(RequestTokenSchema, Object.fromEntries(new URLSearchParams(data)));
 
   zaimOAuthLogger
     .with({ oauthToken: parsed.oauth_token })

--- a/packages/zaim-api/src/oauth/zaim-oauth.test.ts
+++ b/packages/zaim-api/src/oauth/zaim-oauth.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Zaim OAuth エンドポイント定義 (zaim-oauth.ts) のテスト
+ */
+
+import { describe, expect, test } from "vite-plus/test";
+import { buildZaimApiAuthHeader, buildZaimAuthorizeUrl } from "./zaim-oauth.ts";
+import { oauthTest, parseOAuthHeader, RFC } from "./test-fixtures.ts";
+
+describe("buildZaimAuthorizeUrl", () => {
+  test("認可URLにoauth_tokenクエリパラメータを付与する", () => {
+    expect(buildZaimAuthorizeUrl("mytoken123")).toBe(
+      "https://auth.zaim.net/users/auth?oauth_token=mytoken123",
+    );
+  });
+
+  test("oauth_tokenに含まれる特殊文字をパーセントエンコードする", () => {
+    expect(buildZaimAuthorizeUrl("token+with/special=chars")).toBe(
+      "https://auth.zaim.net/users/auth?oauth_token=token%2Bwith%2Fspecial%3Dchars",
+    );
+  });
+});
+
+describe("buildZaimApiAuthHeader", () => {
+  oauthTest(
+    "RFC 5849 Appendix A.2 テストベクターと一致する署名を生成する",
+    async ({ fixedTime: _t, mockedNonce: _n }) => {
+      const header = await buildZaimApiAuthHeader(
+        {
+          consumerKey: RFC.consumerKey,
+          consumerSecret: RFC.consumerSecret,
+          token: RFC.token,
+          tokenSecret: RFC.tokenSecret,
+        },
+        RFC.method,
+        RFC.url,
+        RFC.queryParams,
+      );
+      expect(parseOAuthHeader(header).oauth_signature).toBe(RFC.expectedSignature);
+    },
+  );
+
+  oauthTest(
+    "クエリパラメータが異なれば署名も異なる",
+    async ({ fixedTime: _t, mockedNonce: _n }) => {
+      const withParams = await buildZaimApiAuthHeader(
+        { consumerKey: "key", consumerSecret: "secret" },
+        "GET",
+        "https://api.zaim.net/v2/home/money",
+        { mode: "payment" },
+      );
+      const withoutParams = await buildZaimApiAuthHeader(
+        { consumerKey: "key", consumerSecret: "secret" },
+        "GET",
+        "https://api.zaim.net/v2/home/money",
+      );
+      expect(parseOAuthHeader(withParams).oauth_signature).not.toBe(
+        parseOAuthHeader(withoutParams).oauth_signature,
+      );
+    },
+  );
+});

--- a/packages/zaim-api/src/oauth/zaim-oauth.ts
+++ b/packages/zaim-api/src/oauth/zaim-oauth.ts
@@ -1,0 +1,46 @@
+/**
+ * Zaim API の OAuth 1.0a エンドポイント定義
+ *
+ * エンドポイントの API 契約は TypeSpec (typespec/auth.tsp) で定義。
+ *
+ * Zaim OAuth フロー:
+ *   1. Request Token 取得: POST https://api.zaim.net/v2/auth/request
+ *   2. ユーザー認可: https://auth.zaim.net/users/auth?oauth_token=...
+ *   3. Access Token 取得: POST https://api.zaim.net/v2/auth/access
+ *   4. ユーザー ID 取得: GET https://api.zaim.net/v2/home/user/verify
+ */
+
+import { type OAuth1Config, buildOAuth1AuthorizationHeader } from "./oauth1";
+
+export const ZAIM_AUTHORIZE_URL = "https://auth.zaim.net/users/auth";
+
+export interface RequestTokenResult {
+  oauthToken: string;
+  oauthTokenSecret: string;
+}
+
+export interface AccessTokenResult {
+  oauthToken: string;
+  oauthTokenSecret: string;
+}
+
+/** Zaim ユーザー認可 URL を構築する */
+export function buildZaimAuthorizeUrl(oauthToken: string): string {
+  return `${ZAIM_AUTHORIZE_URL}?oauth_token=${encodeURIComponent(oauthToken)}`;
+}
+
+/**
+ * 保存済みアクセストークンを使って Zaim API リクエスト用の Authorization ヘッダーを生成する
+ * @param config      - Consumer Key / Secret + Access Token / Secret
+ * @param method      - HTTP メソッド
+ * @param url         - クエリ文字列を含まないリクエスト URL
+ * @param queryParams - 署名対象のクエリパラメータ
+ */
+export async function buildZaimApiAuthHeader(
+  config: OAuth1Config,
+  method: string,
+  url: string,
+  queryParams: Record<string, string> = {},
+): Promise<string> {
+  return buildOAuth1AuthorizationHeader(method, url, config, {}, queryParams);
+}

--- a/packages/zaim-api/typespec/auth.tsp
+++ b/packages/zaim-api/typespec/auth.tsp
@@ -12,19 +12,6 @@ using TypeSpec.Http;
  */
 @route("/auth")
 namespace ZaimAPI.Auth {
-  /** Request Token (/v2/auth/request) の正常レスポンスモデル */
-  model RequestTokenResponse {
-    oauth_token: string;
-    oauth_token_secret: string;
-    oauth_callback_confirmed: boolean;
-  }
-
-  /** Access Token (/v2/auth/access) の正常レスポンスモデル */
-  model AccessTokenResponse {
-    oauth_token: string;
-    oauth_token_secret: string;
-  }
-
   /**
    * OAuth 1.0a Request Token の取得
    *

--- a/packages/zaim-api/typespec/auth.tsp
+++ b/packages/zaim-api/typespec/auth.tsp
@@ -1,0 +1,57 @@
+import "@typespec/http";
+import "@typespec/openapi3";
+
+using TypeSpec.Http;
+
+/**
+ * Zaim OAuth 1.0a 認証エンドポイント
+ *
+ * 注意: これらのエンドポイントはリクエスト・レスポンスともに
+ * application/x-www-form-urlencoded 形式であり、標準の JSON API とは異なる。
+ * エラーレスポンスもプレーンテキストで返される。
+ */
+@route("/auth")
+namespace ZaimAPI.Auth {
+  /** Request Token (/v2/auth/request) の正常レスポンスモデル */
+  model RequestTokenResponse {
+    oauth_token: string;
+    oauth_token_secret: string;
+    oauth_callback_confirmed: boolean;
+  }
+
+  /** Access Token (/v2/auth/access) の正常レスポンスモデル */
+  model AccessTokenResponse {
+    oauth_token: string;
+    oauth_token_secret: string;
+  }
+
+  /**
+   * OAuth 1.0a Request Token の取得
+   *
+   * Authorization ヘッダーに OAuth 1.0a 署名を含めて POST する。
+   */
+  @route("/request")
+  @post
+  op requestToken(): {
+    @statusCode statusCode: 200;
+    @body body: string;
+  } | {
+    @statusCode statusCode: 400 | 401;
+    @body body: string;
+  };
+
+  /**
+   * OAuth 1.0a Access Token の取得
+   *
+   * Authorization ヘッダーに OAuth 1.0a 署名 + oauth_verifier を含めて POST する。
+   */
+  @route("/access")
+  @post
+  op accessToken(): {
+    @statusCode statusCode: 200;
+    @body body: string;
+  } | {
+    @statusCode statusCode: 400 | 401;
+    @body body: string;
+  };
+}

--- a/packages/zaim-api/typespec/main.tsp
+++ b/packages/zaim-api/typespec/main.tsp
@@ -6,6 +6,7 @@ import "./category.tsp";
 import "./genre.tsp";
 import "./account.tsp";
 import "./other.tsp";
+import "./auth.tsp";
 
 using TypeSpec.Http;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.100.5(react@19.2.5)
+      valibot:
+        specifier: 'catalog:'
+        version: 1.3.1(typescript@6.0.3)
     devDependencies:
       '@hey-api/openapi-ts':
         specifier: 'catalog:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,9 +179,6 @@ importers:
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.100.5(react@19.2.5)
-      valibot:
-        specifier: 'catalog:'
-        version: 1.3.1(typescript@6.0.3)
     devDependencies:
       '@hey-api/openapi-ts':
         specifier: 'catalog:'


### PR DESCRIPTION

## 概要

Zaim API の OAuth 1.0a 認証エンドポイント (`/v2/auth/request`, `/v2/auth/access`) を TypeSpec で定義し、サーバー側の `fetch()` 呼び出しを生成 SDK クライアントに置き換えました。

## 変更内容

### TypeSpec 定義
- **新規**: `typespec/auth.tsp` — OAuth エンドポイントの API 契約定義（リクエスト/レスポンスモデル、正常系/エラー系のステータスコード）

### zaim-api パッケージ
- **新規**: `src/oauth/zaim-oauth.ts` — 共有型 (`RequestTokenResult`, `AccessTokenResult`) と純粋関数 (`buildZaimAuthorizeUrl`, `buildZaimApiAuthHeader`)
- **新規**: `src/oauth/zaim-oauth.test.ts` — 上記のユニットテスト

### server
- `zaim-oauth.ts` — 3 つの関数を生成 SDK を使用するようリファクタリング:
  - `fetchZaimRequestToken` → `authRequestToken()` (SDK)
  - `fetchZaimAccessToken` → `authAccessToken()` (SDK)
  - `fetchZaimUserId` → `userVerifyUser()` (SDK + OAuth インターセプター)
- OAuth エンドポイントのエラー処理で `response.text()` を SDK の `error` 値に置き換え
- テストを SDK モックベースに更新
