### PR TITLE
feat(server): 店舗一覧エンドポイント追加（GET /api/zaim/stores）

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -7,6 +7,7 @@ import "./logger.ts";
 import { authRoutes } from "./routes/auth.ts";
 import { accountsRoutes } from "./routes/accounts.ts";
 import { categoriesRoutes } from "./routes/categories.ts";
+import { storesRoutes } from "./routes/stores.ts";
 import { zaimRoutes } from "./routes/zaim.ts";
 
 const base = new Hono<{ Bindings: Env }>();
@@ -64,6 +65,7 @@ const app = base
   // Zaim データ取得（/api/zaim/*）- /api/* の OIDC ミドルウェアで保護済み
   .route("/", categoriesRoutes)
   .route("/", accountsRoutes)
+  .route("/", storesRoutes)
   .route("/", healthRoute);
 
 export default app;

--- a/apps/server/src/logger.ts
+++ b/apps/server/src/logger.ts
@@ -19,3 +19,4 @@ export const zaimOAuthLogger = getLogger(["quick-zaim", "server", "zaim-oauth"])
 export const zaimRoutesLogger = getLogger(["quick-zaim", "server", "zaim-routes"]);
 export const categoriesLogger = getLogger(["quick-zaim", "server", "categories"]);
 export const accountsLogger = getLogger(["quick-zaim", "server", "accounts"]);
+export const storesLogger = getLogger(["quick-zaim", "server", "stores"]);

--- a/apps/server/src/routes/stores.test.ts
+++ b/apps/server/src/routes/stores.test.ts
@@ -259,11 +259,9 @@ describe("GET /api/zaim/stores", () => {
 
     await testClient(storesRoutes, makeEnv(kv)).api.zaim.stores.$get({ query: {} });
 
-    expect(mockPut).toHaveBeenCalledWith(
-      "zaim:cache:stores:zaim_user_999",
-      expect.any(String),
-      { expirationTtl: 3600 },
-    );
+    expect(mockPut).toHaveBeenCalledWith("zaim:cache:stores:zaim_user_999", expect.any(String), {
+      expirationTtl: 3600,
+    });
   });
 
   test("取得後に月別moneyキャッシュをKVに書き込む", async () => {

--- a/apps/server/src/routes/stores.test.ts
+++ b/apps/server/src/routes/stores.test.ts
@@ -1,0 +1,306 @@
+/**
+ * stores ルートのテスト
+ *
+ * GET /api/zaim/stores - 店舗一覧（KVキャッシュ付き）
+ *
+ * KV キー:
+ *   zaim:cache:stores:{zaim_user_id}           - 店舗リストキャッシュ
+ *   zaim:cache:money:{zaim_user_id}:{yyyy-mm}  - 月別支払いアイテムキャッシュ
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vite-plus/test";
+import { testClient } from "hono/testing";
+import { createKVNamespaceMock } from "../test-fixtures.ts";
+import { storesRoutes } from "./stores.ts";
+import type { Env } from "../env.ts";
+import type { KVNamespace } from "@cloudflare/workers-types";
+import type { OidcAuth } from "@hono/oidc-auth";
+
+vi.mock("@hono/oidc-auth", () => ({
+  getAuth: vi.fn(),
+  revokeSession: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { mockMoneyGetMoney } = vi.hoisted(() => ({
+  mockMoneyGetMoney: vi.fn(),
+}));
+
+vi.mock("@repo/zaim-api", () => ({
+  moneyGetMoney: mockMoneyGetMoney,
+}));
+
+vi.mock("@repo/zaim-api/client", () => ({
+  createClient: vi.fn(() => ({
+    interceptors: { request: { use: vi.fn() } },
+  })),
+}));
+
+vi.mock("@repo/zaim-api/oauth/interceptor", () => ({
+  createZaimAuthInterceptor: vi.fn(() => () => {}),
+}));
+
+import { getAuth } from "@hono/oidc-auth";
+
+const mockGetAuth = vi.mocked(getAuth);
+
+const MOCK_USER = {
+  sub: "auth0|user123",
+  email: "user@example.com",
+  rtk: "",
+  rtkexp: 9999999999,
+  ssnexp: 9999999999,
+} as OidcAuth;
+
+const STORED_TOKEN = JSON.stringify({
+  oauthToken: "access_token",
+  oauthTokenSecret: "access_secret",
+  zaimUserId: "zaim_user_999",
+});
+
+const MOCK_MONEY_RESPONSE = {
+  money: [
+    {
+      id: 1,
+      mode: "payment",
+      user_id: 999,
+      date: "2026-04-10",
+      category_id: 101,
+      genre_id: 201,
+      to_account_id: 0,
+      from_account_id: 1,
+      amount: 1500,
+      comment: "",
+      active: 1,
+      name: "",
+      receipt_id: 0,
+      place: "スーパーA",
+      place_uid: "uid_super_a",
+      created: "2026-04-10T10:00:00Z",
+      currency_code: "JPY",
+    },
+    {
+      id: 2,
+      mode: "payment",
+      user_id: 999,
+      date: "2026-04-15",
+      category_id: 101,
+      genre_id: 201,
+      to_account_id: 0,
+      from_account_id: 1,
+      amount: 2000,
+      comment: "",
+      active: 1,
+      name: "",
+      receipt_id: 0,
+      place: "スーパーA",
+      place_uid: "uid_super_a",
+      created: "2026-04-15T10:00:00Z",
+      currency_code: "JPY",
+    },
+    {
+      id: 3,
+      mode: "payment",
+      user_id: 999,
+      date: "2026-05-01",
+      category_id: 102,
+      genre_id: 202,
+      to_account_id: 0,
+      from_account_id: 1,
+      amount: 500,
+      comment: "",
+      active: 1,
+      name: "",
+      receipt_id: 0,
+      place: "カフェB",
+      place_uid: "uid_cafe_b",
+      created: "2026-05-01T10:00:00Z",
+      currency_code: "JPY",
+    },
+    {
+      id: 4,
+      mode: "payment",
+      user_id: 999,
+      date: "2026-03-20",
+      category_id: 101,
+      genre_id: 201,
+      to_account_id: 0,
+      from_account_id: 1,
+      amount: 800,
+      comment: "",
+      active: 1,
+      name: "",
+      receipt_id: 0,
+      place: "",
+      place_uid: "",
+      created: "2026-03-20T10:00:00Z",
+      currency_code: "JPY",
+    },
+  ],
+};
+
+function makeEnv(kvOverride?: KVNamespace): Env {
+  const { kv } = createKVNamespaceMock();
+  return {
+    OIDC_ISSUER: "https://example.auth0.com/",
+    OIDC_CLIENT_ID: "test_client_id",
+    OIDC_CLIENT_SECRET: "test_client_secret",
+    OIDC_REDIRECT_URI: "https://example.com/callback",
+    OIDC_AUTH_SECRET: "test_auth_secret_32chars_minimum!",
+    ZAIM_CONSUMER_KEY: "zaim_consumer_key",
+    ZAIM_CONSUMER_SECRET: "zaim_consumer_secret",
+    ZAIM_KV: kvOverride ?? kv,
+  };
+}
+
+// ── GET /api/zaim/stores ──────────────────────────────────────────────────────
+
+describe("GET /api/zaim/stores", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuth.mockResolvedValue(MOCK_USER);
+    mockMoneyGetMoney.mockResolvedValue({ data: MOCK_MONEY_RESPONSE });
+  });
+
+  test("OIDC未認証のとき401を返す", async () => {
+    mockGetAuth.mockResolvedValueOnce(null);
+    const res = await testClient(storesRoutes, makeEnv()).api.zaim.stores.$get({
+      query: {},
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("Zaimトークン未連携のとき403を返す", async () => {
+    const res = await testClient(storesRoutes, makeEnv()).api.zaim.stores.$get({
+      query: {},
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/Zaim/);
+  });
+
+  test("KVキャッシュヒット時はZaim APIを呼ばずにキャッシュを返す", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    const cachedData = {
+      fetchedAt: "2026-01-01T00:00:00.000Z",
+      stores: [{ place: "スーパーA", placeUid: "uid_super_a", latestDate: "2026-04-15", count: 2 }],
+    };
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(JSON.stringify(cachedData));
+
+    const res = await testClient(storesRoutes, makeEnv(kv)).api.zaim.stores.$get({
+      query: {},
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as typeof cachedData;
+    expect(body.fetchedAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(mockMoneyGetMoney).not.toHaveBeenCalled();
+  });
+
+  test("キャッシュミス時はZaim APIを呼んで店舗一覧を返す", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
+
+    const res = await testClient(storesRoutes, makeEnv(kv)).api.zaim.stores.$get({
+      query: {},
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { fetchedAt: string; stores: unknown[] };
+    expect(body.stores).toHaveLength(2);
+    expect(mockMoneyGetMoney).toHaveBeenCalledOnce();
+  });
+
+  test("placeが空のアイテムは店舗リストに含まれない", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
+
+    const res = await testClient(storesRoutes, makeEnv(kv)).api.zaim.stores.$get({
+      query: {},
+    });
+    const body = (await res.json()) as {
+      stores: { place: string }[];
+    };
+    expect(body.stores.every((s) => s.place !== "")).toBe(true);
+  });
+
+  test("同じplace_uidの支払いが集約されてcountとlatestDateが正しい", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
+
+    const res = await testClient(storesRoutes, makeEnv(kv)).api.zaim.stores.$get({
+      query: {},
+    });
+    const body = (await res.json()) as {
+      stores: { place: string; placeUid: string; latestDate: string; count: number }[];
+    };
+
+    const superA = body.stores.find((s) => s.placeUid === "uid_super_a");
+    expect(superA).toBeDefined();
+    expect(superA?.count).toBe(2);
+    expect(superA?.latestDate).toBe("2026-04-15");
+  });
+
+  test("店舗一覧がlatestDate降順で返る", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
+
+    const res = await testClient(storesRoutes, makeEnv(kv)).api.zaim.stores.$get({
+      query: {},
+    });
+    const body = (await res.json()) as {
+      stores: { latestDate: string }[];
+    };
+    const dates = body.stores.map((s) => s.latestDate);
+    const sorted = [...dates].sort((a, b) => b.localeCompare(a));
+    expect(dates).toEqual(sorted);
+  });
+
+  test("取得後に店舗リストをKVにキャッシュする", async () => {
+    const { kv, mockGet, mockPut } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
+
+    await testClient(storesRoutes, makeEnv(kv)).api.zaim.stores.$get({ query: {} });
+
+    expect(mockPut).toHaveBeenCalledWith(
+      "zaim:cache:stores:zaim_user_999",
+      expect.any(String),
+      { expirationTtl: 3600 },
+    );
+  });
+
+  test("取得後に月別moneyキャッシュをKVに書き込む", async () => {
+    const { kv, mockGet, mockPut } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
+
+    await testClient(storesRoutes, makeEnv(kv)).api.zaim.stores.$get({ query: {} });
+
+    const monthlyPuts = mockPut.mock.calls.filter(([key]) =>
+      (key as string).startsWith("zaim:cache:money:"),
+    );
+    expect(monthlyPuts.length).toBeGreaterThan(0);
+  });
+
+  test("no_cache=1のときKVキャッシュを無視してAPIを呼ぶ", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    const cachedData = { fetchedAt: "2026-01-01T00:00:00.000Z", stores: [] };
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(JSON.stringify(cachedData));
+
+    const res = await testClient(storesRoutes, makeEnv(kv)).api.zaim.stores.$get({
+      query: { no_cache: "1" },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { stores: unknown[] };
+    expect(body.stores).toHaveLength(2);
+    expect(mockMoneyGetMoney).toHaveBeenCalledOnce();
+  });
+
+  test("レスポンスにfetchedAt（ISO 8601）が含まれる", async () => {
+    const { kv, mockGet } = createKVNamespaceMock();
+    mockGet.mockResolvedValueOnce(STORED_TOKEN).mockResolvedValueOnce(null);
+
+    const res = await testClient(storesRoutes, makeEnv(kv)).api.zaim.stores.$get({
+      query: {},
+    });
+    const body = (await res.json()) as { fetchedAt: string };
+    expect(() => new Date(body.fetchedAt)).not.toThrow();
+    expect(body.fetchedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});

--- a/apps/server/src/routes/stores.ts
+++ b/apps/server/src/routes/stores.ts
@@ -1,0 +1,236 @@
+/**
+ * Zaim 店舗一覧取得ルート（KV キャッシュ付き）
+ *
+ * エンドポイント:
+ *   GET /api/zaim/stores - 過去の支払いアイテムから集約した店舗一覧を返す
+ *
+ * KV キー設計:
+ *   zaim:cache:stores:{zaim_user_id}           - 店舗リストキャッシュ（TTL 1時間）
+ *   zaim:cache:money:{zaim_user_id}:{yyyy-mm}  - 月別支払いアイテムキャッシュ
+ *     - 過去月: TTL 30日（事実上不変）
+ *     - 当月: TTL 1時間（支払い追加で変化する）
+ */
+
+import { moneyGetMoney } from "@repo/zaim-api";
+import { createClient } from "@repo/zaim-api/client";
+import { sValidator } from "@hono/standard-validator";
+import { getAuth } from "@hono/oidc-auth";
+import { Hono } from "hono";
+import * as v from "valibot";
+import type { Env } from "../env.ts";
+import { getStoredZaimToken } from "./zaim.ts";
+import { createZaimAuthInterceptor } from "@repo/zaim-api/oauth/interceptor";
+import type { OAuth1Config } from "@repo/zaim-api/oauth/oauth1";
+import { storesLogger } from "../logger.ts";
+
+const StoresQuerySchema = v.object({
+  no_cache: v.optional(v.string()),
+});
+
+const ZAIM_API_BASE = "https://api.zaim.net";
+const STORES_CACHE_TTL = 3600;
+const CURRENT_MONTH_MONEY_TTL = 3600;
+const PAST_MONTH_MONEY_TTL = 2592000;
+
+export type Store = {
+  place: string;
+  placeUid: string;
+  latestDate: string;
+  count: number;
+};
+
+export type MoneyItem = {
+  id: number;
+  date: string;
+  amount: number;
+  place: string;
+  placeUid: string;
+  mode: "income" | "payment" | "transfer";
+  categoryId: number;
+  genreId: number;
+};
+
+export type MonthlyMoneyCache = {
+  fetchedAt: string;
+  items: MoneyItem[];
+};
+
+export type StoresResponse = {
+  /** Zaim API からデータを取得した日時（ISO 8601） */
+  fetchedAt: string;
+  stores: Store[];
+};
+
+function currentYearMonth(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+}
+
+function yearMonthOf(date: string): string {
+  return date.slice(0, 7);
+}
+
+async function fetchAllMoneyFromZaim(oauthConfig: OAuth1Config): Promise<MoneyItem[]> {
+  const client = createClient({ baseUrl: ZAIM_API_BASE });
+  client.interceptors.request.use(createZaimAuthInterceptor(oauthConfig));
+
+  storesLogger.debug("Fetching all money items from Zaim API");
+
+  const result = await moneyGetMoney({
+    client,
+    query: { mapping: 1, mode: "payment" },
+  });
+
+  if (!result.data) {
+    storesLogger.error("Failed to fetch money items from Zaim API");
+    throw new Error("Failed to fetch money items from Zaim API");
+  }
+
+  const items = result.data.money
+    .filter((m) => m.place)
+    .map((m) => ({
+      id: m.id,
+      date: m.date,
+      amount: m.amount,
+      place: m.place,
+      placeUid: m.place_uid,
+      mode: m.mode as "income" | "payment" | "transfer",
+      categoryId: m.category_id,
+      genreId: m.genre_id,
+    }));
+
+  storesLogger.with({ itemCount: items.length }).debug("Zaim API returned {itemCount} money items with places");
+
+  return items;
+}
+
+function aggregateStores(items: MoneyItem[]): Store[] {
+  const storeMap = new Map<string, Store>();
+
+  for (const item of items) {
+    const key = item.placeUid || item.place;
+    const existing = storeMap.get(key);
+    if (existing) {
+      existing.count++;
+      if (item.date > existing.latestDate) {
+        existing.latestDate = item.date;
+      }
+    } else {
+      storeMap.set(key, {
+        place: item.place,
+        placeUid: item.placeUid,
+        latestDate: item.date,
+        count: 1,
+      });
+    }
+  }
+
+  return Array.from(storeMap.values()).sort((a, b) => b.latestDate.localeCompare(a.latestDate));
+}
+
+async function buildAndCacheMonthlyData(
+  kv: KVNamespace,
+  zaimUserId: string,
+  items: MoneyItem[],
+): Promise<void> {
+  const thisMonth = currentYearMonth();
+  const byMonth = new Map<string, MoneyItem[]>();
+
+  for (const item of items) {
+    const ym = yearMonthOf(item.date);
+    const group = byMonth.get(ym);
+    if (group) {
+      group.push(item);
+    } else {
+      byMonth.set(ym, [item]);
+    }
+  }
+
+  const fetchedAt = new Date().toISOString();
+  const puts: Promise<void>[] = [];
+
+  for (const [ym, monthItems] of byMonth) {
+    const cacheKey = `zaim:cache:money:${zaimUserId}:${ym}`;
+    const ttl = ym < thisMonth ? PAST_MONTH_MONEY_TTL : CURRENT_MONTH_MONEY_TTL;
+    const value: MonthlyMoneyCache = { fetchedAt, items: monthItems };
+    puts.push(kv.put(cacheKey, JSON.stringify(value), { expirationTtl: ttl }));
+  }
+
+  await Promise.all(puts);
+
+  storesLogger
+    .with({ zaimUserId, monthCount: byMonth.size })
+    .debug("Cached {monthCount} monthly money caches for Zaim user {zaimUserId}");
+}
+
+const getStoresRoute = new Hono<{ Bindings: Env }>().get(
+  "/api/zaim/stores",
+  sValidator("query", StoresQuerySchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ error: "Invalid query parameters" }, 400);
+    }
+  }),
+  async (c) => {
+    const auth = await getAuth(c);
+    if (!auth?.sub) {
+      storesLogger.warn("Stores: unauthorized (no OIDC session)");
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    const token = await getStoredZaimToken(c.env.ZAIM_KV, auth.sub);
+    if (!token) {
+      storesLogger.with({ userSub: auth.sub }).warn("Stores: Zaim not connected for {userSub}");
+      return c.json({ error: "Zaim not connected" }, 403);
+    }
+
+    const { no_cache: noCache } = c.req.valid("query");
+    const storesCacheKey = `zaim:cache:stores:${token.zaimUserId}`;
+
+    if (noCache !== "1") {
+      const cached = await c.env.ZAIM_KV.get(storesCacheKey);
+      if (cached) {
+        storesLogger
+          .with({ zaimUserId: token.zaimUserId })
+          .debug("Stores cache hit for Zaim user {zaimUserId}");
+        return c.json(JSON.parse(cached) as StoresResponse);
+      }
+      storesLogger
+        .with({ zaimUserId: token.zaimUserId })
+        .debug("Stores cache miss for Zaim user {zaimUserId}, fetching from API");
+    } else {
+      storesLogger
+        .with({ zaimUserId: token.zaimUserId })
+        .debug("Stores cache bypassed (no_cache=1) for Zaim user {zaimUserId}");
+    }
+
+    const oauthConfig: OAuth1Config = {
+      consumerKey: c.env.ZAIM_CONSUMER_KEY,
+      consumerSecret: c.env.ZAIM_CONSUMER_SECRET,
+      token: token.oauthToken,
+      tokenSecret: token.oauthTokenSecret,
+    };
+
+    const items = await fetchAllMoneyFromZaim(oauthConfig);
+
+    await buildAndCacheMonthlyData(c.env.ZAIM_KV, token.zaimUserId, items);
+
+    const stores = aggregateStores(items);
+    const response: StoresResponse = {
+      fetchedAt: new Date().toISOString(),
+      stores,
+    };
+
+    await c.env.ZAIM_KV.put(storesCacheKey, JSON.stringify(response), {
+      expirationTtl: STORES_CACHE_TTL,
+    });
+    storesLogger
+      .with({ zaimUserId: token.zaimUserId, storeCount: stores.length, ttl: STORES_CACHE_TTL })
+      .debug("Stores cached for Zaim user {zaimUserId} ({storeCount} stores, TTL={ttl}s)");
+
+    return c.json(response);
+  },
+);
+
+export const storesRoutes = new Hono<{ Bindings: Env }>().route("/", getStoresRoute);

--- a/apps/server/src/routes/stores.ts
+++ b/apps/server/src/routes/stores.ts
@@ -115,7 +115,9 @@ async function fetchAllMoneyFromZaim(oauthConfig: OAuth1Config): Promise<MoneyIt
       genreId: m.genre_id,
     }));
 
-  storesLogger.with({ itemCount: items.length }).debug("Zaim API returned {itemCount} money items with places");
+  storesLogger
+    .with({ itemCount: items.length })
+    .debug("Zaim API returned {itemCount} money items with places");
 
   return items;
 }

--- a/apps/server/src/routes/stores.ts
+++ b/apps/server/src/routes/stores.ts
@@ -88,7 +88,21 @@ async function fetchAllMoneyFromZaim(oauthConfig: OAuth1Config): Promise<MoneyIt
     throw new Error("Failed to fetch money items from Zaim API");
   }
 
-  const items = result.data.money
+  // result.data.money may be typed as any[] depending on the generated client version,
+  // so we explicitly assert the shape to avoid TS7006 implicit-any errors.
+  type ZaimMoneyApiItem = {
+    id: number;
+    mode: "income" | "payment" | "transfer";
+    date: string;
+    category_id: number;
+    genre_id: number;
+    amount: number;
+    place: string;
+    place_uid: string;
+  };
+  const moneyList = result.data.money as ZaimMoneyApiItem[];
+
+  const items = moneyList
     .filter((m) => m.place)
     .map((m) => ({
       id: m.id,
@@ -96,7 +110,7 @@ async function fetchAllMoneyFromZaim(oauthConfig: OAuth1Config): Promise<MoneyIt
       amount: m.amount,
       place: m.place,
       placeUid: m.place_uid,
-      mode: m.mode as "income" | "payment" | "transfer",
+      mode: m.mode,
       categoryId: m.category_id,
       genreId: m.genre_id,
     }));


### PR DESCRIPTION
過去の支払いアイテムから店舗を集約して返すエンドポイントを実装する。
KV キャッシュは店舗リスト（TTL 1時間）と月別支払いアイテム（当月 1時間・過去月 30日）
の 2 層構造とし、将来の支払い登録時の重複チェックを可能にする。

https://claude.ai/code/session_01LjTESH7DYx2k8kuD1q894C