### PR TITLE
refactor(server): Honoミドルウェアによるリクエストスコープloggerの導入

### DIFF
--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -1,4 +1,5 @@
 import type { KVNamespace } from "@cloudflare/workers-types";
+import type { Logger } from "./loggerMiddleware.ts";
 
 /**
  * Cloudflare Workers の環境変数（バインディング）の型定義
@@ -25,4 +26,4 @@ export type Env = {
 };
 
 /** Hono アプリ全体で共有する環境型 */
-export type HonoEnv = { Bindings: Env };
+export type HonoEnv = { Bindings: Env; Variables: { logger: Logger } };

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,9 +1,9 @@
 import { oidcAuthMiddleware } from "@hono/oidc-auth";
-import { honoLogger } from "@logtape/hono";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import type { HonoEnv, Env } from "./env.ts";
 import "./logger.ts";
+import { loggerMiddleware } from "./loggerMiddleware.ts";
 import { requireOidcAuth } from "./middleware.ts";
 import { authRoutes } from "./routes/auth.ts";
 import { accountsRoutes } from "./routes/accounts.ts";
@@ -14,7 +14,7 @@ import { zaimRoutes } from "./routes/zaim.ts";
 
 const base = new Hono<HonoEnv>();
 
-base.use(honoLogger({ category: ["quick-zaim", "server"] }));
+base.use(loggerMiddleware);
 
 // Chrome拡張機能・ローカル開発からのクロスオリジンリクエストを許可
 base.use(

--- a/apps/server/src/logger.ts
+++ b/apps/server/src/logger.ts
@@ -1,4 +1,4 @@
-import { configureSync, getConsoleSink, getLogger } from "@logtape/logtape";
+import { configureSync, getConsoleSink } from "@logtape/logtape";
 
 configureSync({
   sinks: {
@@ -13,11 +13,3 @@ configureSync({
   ],
   reset: true,
 });
-
-export const authLogger = getLogger(["quick-zaim", "server", "auth"]);
-export const zaimOAuthLogger = getLogger(["quick-zaim", "server", "zaim-oauth"]);
-export const zaimRoutesLogger = getLogger(["quick-zaim", "server", "zaim-routes"]);
-export const categoriesLogger = getLogger(["quick-zaim", "server", "categories"]);
-export const accountsLogger = getLogger(["quick-zaim", "server", "accounts"]);
-export const storesLogger = getLogger(["quick-zaim", "server", "stores"]);
-export const paymentLogger = getLogger(["quick-zaim", "server", "payment"]);

--- a/apps/server/src/loggerMiddleware.ts
+++ b/apps/server/src/loggerMiddleware.ts
@@ -1,0 +1,26 @@
+import { getLogger } from "@logtape/logtape";
+import type { Logger } from "@logtape/logtape";
+import { createMiddleware } from "hono/factory";
+
+export type { Logger };
+
+export const loggerMiddleware = createMiddleware<{
+  Variables: { logger: Logger };
+}>(async (c, next) => {
+  const requestId = crypto.randomUUID();
+  const logger = getLogger(["quick-zaim", "server"]).with({
+    requestId,
+    method: c.req.method,
+    path: c.req.path,
+  });
+
+  c.set("logger", logger);
+
+  logger.debug("<-- {method} {path}");
+
+  const start = Date.now();
+  await next();
+  const duration = Date.now() - start;
+
+  logger.with({ status: c.res.status, duration }).info("--> {method} {path} {status} {duration}ms");
+});

--- a/apps/server/src/routes/accounts.ts
+++ b/apps/server/src/routes/accounts.ts
@@ -14,8 +14,8 @@ import { sValidator } from "@hono/standard-validator";
 import { Hono } from "hono";
 import * as v from "valibot";
 import type { HonoEnv } from "../env.ts";
+import type { Logger } from "../loggerMiddleware.ts";
 import { requireOidcAuth, requireZaimClient } from "../middleware.ts";
-import { accountsLogger } from "../logger.ts";
 
 const AccountsQuerySchema = v.object({
   no_cache: v.optional(v.string()),
@@ -42,8 +42,9 @@ export type AccountsResponse = {
 
 async function fetchAccountsFromZaim(
   client: ReturnType<typeof createClient>,
+  logger: Logger,
 ): Promise<AccountsResponse> {
-  accountsLogger.debug("Fetching accounts from Zaim API");
+  logger.debug("Fetching accounts from Zaim API");
 
   const result = await accountGetAccounts({
     client,
@@ -51,12 +52,12 @@ async function fetchAccountsFromZaim(
   });
 
   if (!result.data) {
-    accountsLogger.error("Failed to fetch accounts from Zaim API");
+    logger.error("Failed to fetch accounts from Zaim API");
     throw new Error("Failed to fetch accounts from Zaim API");
   }
 
   const accountCount = result.data.accounts.length;
-  accountsLogger.with({ accountCount }).debug("Zaim API returned {accountCount} accounts");
+  logger.with({ accountCount }).debug("Zaim API returned {accountCount} accounts");
 
   return {
     fetchedAt: new Date().toISOString(),
@@ -88,6 +89,7 @@ const getAccountsRoute = new Hono<HonoEnv>().get(
     }
   }),
   async (c) => {
+    const logger = c.var.logger;
     const { zaimClient, zaimUserId } = c.var;
 
     const { no_cache: noCache } = c.req.valid("query");
@@ -96,22 +98,22 @@ const getAccountsRoute = new Hono<HonoEnv>().get(
     if (noCache !== "1") {
       const cached = await c.env.ZAIM_KV.get(cacheKey);
       if (cached) {
-        accountsLogger.with({ zaimUserId }).debug("Accounts cache hit for Zaim user {zaimUserId}");
+        logger.with({ zaimUserId }).debug("Accounts cache hit for Zaim user {zaimUserId}");
         return c.json(JSON.parse(cached) as AccountsResponse);
       }
-      accountsLogger
+      logger
         .with({ zaimUserId })
         .debug("Accounts cache miss for Zaim user {zaimUserId}, fetching from API");
     } else {
-      accountsLogger
+      logger
         .with({ zaimUserId })
         .debug("Accounts cache bypassed (no_cache=1) for Zaim user {zaimUserId}");
     }
 
-    const result = await fetchAccountsFromZaim(zaimClient);
+    const result = await fetchAccountsFromZaim(zaimClient, logger);
 
     await c.env.ZAIM_KV.put(cacheKey, JSON.stringify(result), { expirationTtl: CACHE_TTL });
-    accountsLogger
+    logger
       .with({ zaimUserId, ttl: CACHE_TTL })
       .debug("Accounts cached for Zaim user {zaimUserId} (TTL={ttl}s)");
 

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -3,7 +3,6 @@ import { revokeSession } from "@hono/oidc-auth";
 import { Hono } from "hono";
 import * as v from "valibot";
 import type { HonoEnv } from "../env.ts";
-import { authLogger } from "../logger.ts";
 
 function isValidExtensionRedirectUri(uri: string): boolean {
   try {
@@ -21,7 +20,8 @@ function isValidExtensionRedirectUri(uri: string): boolean {
  * 次回アクセス時に別アカウントを選択できるようになる。
  */
 const logoutRoute = new Hono<HonoEnv>().get("/logout", async (c) => {
-  authLogger.info("Logout requested");
+  const logger = c.var.logger;
+  logger.info("Logout requested");
 
   await revokeSession(c);
 
@@ -30,7 +30,7 @@ const logoutRoute = new Hono<HonoEnv>().get("/logout", async (c) => {
   const returnTo = new URL("/", c.req.url).toString();
   const logoutUrl = `${issuer}/v2/logout?client_id=${clientId}&returnTo=${encodeURIComponent(returnTo)}`;
 
-  authLogger.info("Session revoked, redirecting to Auth0 logout");
+  logger.info("Session revoked, redirecting to Auth0 logout");
   return c.redirect(logoutUrl);
 });
 
@@ -41,9 +41,7 @@ const logoutRoute = new Hono<HonoEnv>().get("/logout", async (c) => {
  */
 const meRoute = new Hono<HonoEnv>().get("/me", async (c) => {
   const auth = c.var.oidcAuth;
-  authLogger
-    .with({ email: auth?.email, sub: auth?.sub })
-    .info("User info requested for {email}", { email: auth?.email });
+  c.var.logger.with({ email: auth?.email, sub: auth?.sub }).info("User info requested for {email}");
   return c.json({
     email: auth?.email,
     sub: auth?.sub,
@@ -64,14 +62,15 @@ const launchRoute = new Hono<HonoEnv>().get(
     if (!result.success) return c.json({ error: "Missing redirect_uri" }, 400);
   }),
   async (c) => {
+    const logger = c.var.logger;
     const { redirect_uri } = c.req.valid("query");
     if (!isValidExtensionRedirectUri(redirect_uri)) {
-      authLogger
+      logger
         .with({ redirectUri: redirect_uri })
         .warn("Extension auth launch: invalid redirect_uri: {redirectUri}");
       return c.json({ error: "Invalid redirect_uri" }, 400);
     }
-    authLogger
+    logger
       .with({ redirectUri: redirect_uri })
       .info("Extension auth launch: redirecting to {redirectUri}");
     return c.redirect(redirect_uri);

--- a/apps/server/src/routes/categories.ts
+++ b/apps/server/src/routes/categories.ts
@@ -14,8 +14,8 @@ import { sValidator } from "@hono/standard-validator";
 import { Hono } from "hono";
 import * as v from "valibot";
 import type { HonoEnv } from "../env.ts";
+import type { Logger } from "../loggerMiddleware.ts";
 import { requireOidcAuth, requireZaimClient } from "../middleware.ts";
-import { categoriesLogger } from "../logger.ts";
 
 const CategoriesQuerySchema = v.object({
   no_cache: v.optional(v.string()),
@@ -40,8 +40,9 @@ export type CategoriesResponse = {
 
 async function fetchCategoriesFromZaim(
   client: ReturnType<typeof createClient>,
+  logger: Logger,
 ): Promise<CategoriesResponse> {
-  categoriesLogger.debug("Fetching categories and genres from Zaim API in parallel");
+  logger.debug("Fetching categories and genres from Zaim API in parallel");
 
   const [categoriesResult, genresResult] = await Promise.all([
     categoryGetCategories({
@@ -55,13 +56,13 @@ async function fetchCategoriesFromZaim(
   ]);
 
   if (!categoriesResult.data || !genresResult.data) {
-    categoriesLogger.error("Failed to fetch categories or genres from Zaim API");
+    logger.error("Failed to fetch categories or genres from Zaim API");
     throw new Error("Failed to fetch categories from Zaim API");
   }
 
   const categoryCount = categoriesResult.data.categories.length;
   const genreCount = genresResult.data.genres.length;
-  categoriesLogger
+  logger
     .with({ categoryCount, genreCount })
     .debug("Zaim API returned {categoryCount} categories and {genreCount} genres");
 
@@ -93,6 +94,7 @@ const getCategoriesRoute = new Hono<HonoEnv>().get(
     }
   }),
   async (c) => {
+    const logger = c.var.logger;
     const { zaimClient, zaimUserId } = c.var;
 
     const { no_cache: noCache } = c.req.valid("query");
@@ -101,24 +103,22 @@ const getCategoriesRoute = new Hono<HonoEnv>().get(
     if (noCache !== "1") {
       const cached = await c.env.ZAIM_KV.get(cacheKey);
       if (cached) {
-        categoriesLogger
-          .with({ zaimUserId })
-          .debug("Categories cache hit for Zaim user {zaimUserId}");
+        logger.with({ zaimUserId }).debug("Categories cache hit for Zaim user {zaimUserId}");
         return c.json(JSON.parse(cached) as CategoriesResponse);
       }
-      categoriesLogger
+      logger
         .with({ zaimUserId })
         .debug("Categories cache miss for Zaim user {zaimUserId}, fetching from API");
     } else {
-      categoriesLogger
+      logger
         .with({ zaimUserId })
         .debug("Categories cache bypassed (no_cache=1) for Zaim user {zaimUserId}");
     }
 
-    const result = await fetchCategoriesFromZaim(zaimClient);
+    const result = await fetchCategoriesFromZaim(zaimClient, logger);
 
     await c.env.ZAIM_KV.put(cacheKey, JSON.stringify(result), { expirationTtl: CACHE_TTL });
-    categoriesLogger
+    logger
       .with({ zaimUserId, ttl: CACHE_TTL })
       .debug("Categories cached for Zaim user {zaimUserId} (TTL={ttl}s)");
 

--- a/apps/server/src/routes/payment.ts
+++ b/apps/server/src/routes/payment.ts
@@ -17,7 +17,6 @@ import { Hono } from "hono";
 import * as v from "valibot";
 import type { HonoEnv } from "../env.ts";
 import { requireOidcAuth, requireZaimClient } from "../middleware.ts";
-import { paymentLogger } from "../logger.ts";
 import type { MoneyItem, MonthlyMoneyCache } from "./stores.ts";
 
 const CURRENT_MONTH_MONEY_TTL = 3600;
@@ -113,10 +112,11 @@ const createPaymentRoute = new Hono<HonoEnv>().post(
     if (!result.success) return c.json({ error: "Invalid request body" }, 400);
   }),
   async (c) => {
+    const logger = c.var.logger;
     const { zaimClient, zaimUserId } = c.var;
     const body = c.req.valid("json");
 
-    paymentLogger
+    logger
       .with({ zaimUserId, amount: body.amount, date: body.date })
       .debug("Registering payment for Zaim user {zaimUserId}");
 
@@ -137,7 +137,7 @@ const createPaymentRoute = new Hono<HonoEnv>().post(
     });
 
     if (!result.data) {
-      paymentLogger.error("Failed to create payment in Zaim API");
+      logger.error("Failed to create payment in Zaim API");
       return c.json({ error: "Failed to create payment" }, 502);
     }
 
@@ -147,7 +147,7 @@ const createPaymentRoute = new Hono<HonoEnv>().post(
       c.env.ZAIM_KV.delete(`zaim:cache:stores:${zaimUserId}`),
     ]);
 
-    paymentLogger
+    logger
       .with({ zaimUserId, id: result.data.money.id })
       .debug("Payment registered for Zaim user {zaimUserId}, id={id}");
 
@@ -174,6 +174,7 @@ const getDuplicateRoute = new Hono<HonoEnv>().get(
     if (!result.success) return c.json({ error: "Invalid query parameters" }, 400);
   }),
   async (c) => {
+    const logger = c.var.logger;
     const { zaimClient, zaimUserId } = c.var;
     const { date, amount, genre_id: genreId } = c.req.valid("query");
 
@@ -184,12 +185,12 @@ const getDuplicateRoute = new Hono<HonoEnv>().get(
 
     const cached = await c.env.ZAIM_KV.get(cacheKey);
     if (cached) {
-      paymentLogger
+      logger
         .with({ zaimUserId, yearMonth })
         .debug("Monthly money cache hit for duplicate check ({yearMonth})");
       items = (JSON.parse(cached) as MonthlyMoneyCache).items;
     } else {
-      paymentLogger
+      logger
         .with({ zaimUserId, yearMonth })
         .debug("Monthly money cache miss for duplicate check ({yearMonth}), fetching from API");
       items = await fetchMonthlyMoneyItems(zaimClient, yearMonth);
@@ -210,7 +211,7 @@ const getDuplicateRoute = new Hono<HonoEnv>().get(
         item.date <= maxDate,
     );
 
-    paymentLogger
+    logger
       .with({ zaimUserId, duplicateCount: duplicates.length })
       .debug("Duplicate check found {duplicateCount} potential duplicates");
 

--- a/apps/server/src/routes/stores.ts
+++ b/apps/server/src/routes/stores.ts
@@ -17,8 +17,8 @@ import { sValidator } from "@hono/standard-validator";
 import { Hono } from "hono";
 import * as v from "valibot";
 import type { HonoEnv } from "../env.ts";
+import type { Logger } from "../loggerMiddleware.ts";
 import { requireOidcAuth, requireZaimClient } from "../middleware.ts";
-import { storesLogger } from "../logger.ts";
 
 const StoresQuerySchema = v.object({
   no_cache: v.optional(v.string()),
@@ -70,8 +70,9 @@ function yearMonthOf(date: string): string {
 
 async function fetchAllMoneyFromZaim(
   client: ReturnType<typeof createClient>,
+  logger: Logger,
 ): Promise<MoneyItem[]> {
-  storesLogger.debug("Fetching all money items from Zaim API");
+  logger.debug("Fetching all money items from Zaim API");
 
   const result = await moneyGetMoney({
     client,
@@ -79,7 +80,7 @@ async function fetchAllMoneyFromZaim(
   });
 
   if (!result.data) {
-    storesLogger.error("Failed to fetch money items from Zaim API");
+    logger.error("Failed to fetch money items from Zaim API");
     throw new Error("Failed to fetch money items from Zaim API");
   }
 
@@ -110,7 +111,7 @@ async function fetchAllMoneyFromZaim(
       genreId: m.genre_id,
     }));
 
-  storesLogger
+  logger
     .with({ itemCount: items.length })
     .debug("Zaim API returned {itemCount} money items with places");
 
@@ -145,6 +146,7 @@ async function buildAndCacheMonthlyData(
   kv: KVNamespace,
   zaimUserId: string,
   items: MoneyItem[],
+  logger: Logger,
 ): Promise<void> {
   const thisMonth = currentYearMonth();
   const byMonth = new Map<string, MoneyItem[]>();
@@ -171,7 +173,7 @@ async function buildAndCacheMonthlyData(
 
   await Promise.all(puts);
 
-  storesLogger
+  logger
     .with({ zaimUserId, monthCount: byMonth.size })
     .debug("Cached {monthCount} monthly money caches for Zaim user {zaimUserId}");
 }
@@ -186,6 +188,7 @@ const getStoresRoute = new Hono<HonoEnv>().get(
     }
   }),
   async (c) => {
+    const logger = c.var.logger;
     const { zaimClient, zaimUserId } = c.var;
 
     const { no_cache: noCache } = c.req.valid("query");
@@ -194,21 +197,21 @@ const getStoresRoute = new Hono<HonoEnv>().get(
     if (noCache !== "1") {
       const cached = await c.env.ZAIM_KV.get(storesCacheKey);
       if (cached) {
-        storesLogger.with({ zaimUserId }).debug("Stores cache hit for Zaim user {zaimUserId}");
+        logger.with({ zaimUserId }).debug("Stores cache hit for Zaim user {zaimUserId}");
         return c.json(JSON.parse(cached) as StoresResponse);
       }
-      storesLogger
+      logger
         .with({ zaimUserId })
         .debug("Stores cache miss for Zaim user {zaimUserId}, fetching from API");
     } else {
-      storesLogger
+      logger
         .with({ zaimUserId })
         .debug("Stores cache bypassed (no_cache=1) for Zaim user {zaimUserId}");
     }
 
-    const items = await fetchAllMoneyFromZaim(zaimClient);
+    const items = await fetchAllMoneyFromZaim(zaimClient, logger);
 
-    await buildAndCacheMonthlyData(c.env.ZAIM_KV, zaimUserId, items);
+    await buildAndCacheMonthlyData(c.env.ZAIM_KV, zaimUserId, items, logger);
 
     const stores = aggregateStores(items);
     const response: StoresResponse = {
@@ -219,7 +222,7 @@ const getStoresRoute = new Hono<HonoEnv>().get(
     await c.env.ZAIM_KV.put(storesCacheKey, JSON.stringify(response), {
       expirationTtl: STORES_CACHE_TTL,
     });
-    storesLogger
+    logger
       .with({ zaimUserId, storeCount: stores.length, ttl: STORES_CACHE_TTL })
       .debug("Stores cached for Zaim user {zaimUserId} ({storeCount} stores, TTL={ttl}s)");
 

--- a/apps/server/src/routes/zaim.ts
+++ b/apps/server/src/routes/zaim.ts
@@ -16,13 +16,13 @@ import { sValidator } from "@hono/standard-validator";
 import { Hono } from "hono";
 import * as v from "valibot";
 import type { Env, HonoEnv } from "../env.ts";
+import type { Logger } from "../loggerMiddleware.ts";
 import {
   buildZaimAuthorizeUrl,
   fetchZaimAccessToken,
   fetchZaimRequestToken,
   fetchZaimUserId,
 } from "../zaim-oauth.ts";
-import { zaimRoutesLogger } from "../logger.ts";
 
 /** Request Token の有効期限（秒） */
 const REQUEST_TOKEN_TTL = 600;
@@ -70,16 +70,13 @@ async function performZaimTokenExchange(
   env: Env,
   oauthToken: string,
   oauthVerifier: string,
+  logger: Logger,
 ): Promise<{ zaimUserId: string; extRedirectUri?: string }> {
-  zaimRoutesLogger
-    .with({ oauthToken })
-    .debug("Looking up request token state from KV: {oauthToken}");
+  logger.with({ oauthToken }).debug("Looking up request token state from KV: {oauthToken}");
 
   const stored = await env.ZAIM_KV.get(`zaim:request:${oauthToken}`);
   if (!stored) {
-    zaimRoutesLogger
-      .with({ oauthToken })
-      .warn("Request token not found or expired in KV: {oauthToken}");
+    logger.with({ oauthToken }).warn("Request token not found or expired in KV: {oauthToken}");
     throw new Error("Request token not found or expired");
   }
 
@@ -88,7 +85,7 @@ async function performZaimTokenExchange(
     JSON.parse(stored),
   );
 
-  zaimRoutesLogger
+  logger
     .with({ userSub, oauthToken })
     .debug("Request token state found for user {userSub}, starting access token exchange");
 
@@ -102,6 +99,7 @@ async function performZaimTokenExchange(
   const { oauthToken: accessToken, oauthTokenSecret } = await fetchZaimAccessToken(
     accessConfig,
     oauthVerifier,
+    logger,
   );
 
   const accessTokenConfig = {
@@ -111,9 +109,9 @@ async function performZaimTokenExchange(
     tokenSecret: oauthTokenSecret,
   };
 
-  const zaimUserId = await fetchZaimUserId(accessTokenConfig);
+  const zaimUserId = await fetchZaimUserId(accessTokenConfig, logger);
 
-  zaimRoutesLogger
+  logger
     .with({ userSub, zaimUserId })
     .info("Access token obtained for user {userSub} (Zaim user {zaimUserId}), saving to KV");
 
@@ -126,7 +124,7 @@ async function performZaimTokenExchange(
   await env.ZAIM_KV.put(`zaim:token:${userSub}`, JSON.stringify(tokenData));
   await env.ZAIM_KV.delete(`zaim:request:${oauthToken}`);
 
-  zaimRoutesLogger
+  logger
     .with({ userSub, zaimUserId })
     .debug("Token exchange complete: access token stored, request token deleted");
 
@@ -150,21 +148,22 @@ const startRoute = new Hono<HonoEnv>().get(
     if (!result.success) return c.json({ error: "Invalid query" }, 400);
   }),
   async (c) => {
+    const logger = c.var.logger;
     const auth = c.var.oidcAuth;
     if (!auth?.sub) {
-      zaimRoutesLogger.warn("Zaim auth start: unauthorized (no OIDC session)");
+      logger.warn("Zaim auth start: unauthorized (no OIDC session)");
       return c.json({ error: "Unauthorized" }, 401);
     }
 
     const { ext_redirect_uri } = c.req.valid("query");
     if (ext_redirect_uri !== undefined && !isValidExtensionRedirectUri(ext_redirect_uri)) {
-      zaimRoutesLogger
+      logger
         .with({ extRedirectUri: ext_redirect_uri })
         .warn("Zaim auth start: invalid ext_redirect_uri: {extRedirectUri}");
       return c.json({ error: "Invalid ext_redirect_uri" }, 400);
     }
 
-    zaimRoutesLogger
+    logger
       .with({ userSub: auth.sub, extFlow: ext_redirect_uri !== undefined })
       .info("Zaim auth start for user {userSub} (ext_flow={extFlow})");
 
@@ -176,6 +175,7 @@ const startRoute = new Hono<HonoEnv>().get(
         consumerSecret: c.env.ZAIM_CONSUMER_SECRET,
       },
       callbackUrl,
+      logger,
     );
 
     const state: RequestTokenState = {
@@ -188,18 +188,18 @@ const startRoute = new Hono<HonoEnv>().get(
       expirationTtl: REQUEST_TOKEN_TTL,
     });
 
-    zaimRoutesLogger
+    logger
       .with({ oauthToken, userSub: auth.sub, ttl: REQUEST_TOKEN_TTL })
       .debug("Request token stored in KV: {oauthToken} (TTL={ttl}s)");
 
     const authorizeUrl = buildZaimAuthorizeUrl(oauthToken);
 
     if (ext_redirect_uri !== undefined) {
-      zaimRoutesLogger.debug("Returning authorizeUrl for extension flow");
+      logger.debug("Returning authorizeUrl for extension flow");
       return c.json({ authorizeUrl });
     }
 
-    zaimRoutesLogger.debug("Redirecting to Zaim authorize URL");
+    logger.debug("Redirecting to Zaim authorize URL");
     return c.redirect(authorizeUrl);
   },
 );
@@ -221,32 +221,32 @@ const callbackRoute = new Hono<HonoEnv>().get(
     }
   }),
   async (c) => {
+    const logger = c.var.logger;
     const { oauth_token: oauthToken, oauth_verifier: oauthVerifier } = c.req.valid("query");
 
-    zaimRoutesLogger.with({ oauthToken }).info("Zaim auth callback received: {oauthToken}");
+    logger.with({ oauthToken }).info("Zaim auth callback received: {oauthToken}");
 
     try {
       const { zaimUserId, extRedirectUri } = await performZaimTokenExchange(
         c.env,
         oauthToken,
         oauthVerifier,
+        logger,
       );
 
-      zaimRoutesLogger
+      logger
         .with({ zaimUserId, extFlow: !!extRedirectUri })
         .info("Zaim token exchange successful for Zaim user {zaimUserId}");
 
       if (extRedirectUri) {
-        zaimRoutesLogger.debug("Redirecting to extension callback URL");
+        logger.debug("Redirecting to extension callback URL");
         return c.redirect(extRedirectUri);
       }
 
       return c.json({ ok: true, zaimUserId });
     } catch (e) {
       const message = e instanceof Error ? e.message : "Token exchange failed";
-      zaimRoutesLogger
-        .with({ oauthToken, error: message })
-        .error("Zaim token exchange failed: {error}");
+      logger.with({ oauthToken, error: message }).error("Zaim token exchange failed: {error}");
       return c.json({ error: message }, 400);
     }
   },
@@ -257,24 +257,23 @@ const callbackRoute = new Hono<HonoEnv>().get(
  * アクセストークンが保存されているかどうかを返す。
  */
 const statusRoute = new Hono<HonoEnv>().get("/zaim/auth/status", async (c) => {
+  const logger = c.var.logger;
   const auth = c.var.oidcAuth;
   if (!auth) {
-    zaimRoutesLogger.warn("Zaim auth status: unauthorized (no OIDC session)");
+    logger.warn("Zaim auth status: unauthorized (no OIDC session)");
     return c.json({ error: "Unauthorized" }, 401);
   }
 
-  zaimRoutesLogger
-    .with({ userSub: auth.sub })
-    .debug("Checking Zaim connection status for {userSub}");
+  logger.with({ userSub: auth.sub }).debug("Checking Zaim connection status for {userSub}");
 
   const stored = await c.env.ZAIM_KV.get(`zaim:token:${auth.sub}`);
   if (!stored) {
-    zaimRoutesLogger.with({ userSub: auth.sub }).debug("Zaim not connected for {userSub}");
+    logger.with({ userSub: auth.sub }).debug("Zaim not connected for {userSub}");
     return c.json({ connected: false });
   }
 
   const { zaimUserId } = v.parse(StoredAccessTokenSchema, JSON.parse(stored));
-  zaimRoutesLogger
+  logger
     .with({ userSub: auth.sub, zaimUserId })
     .debug("Zaim connected for {userSub} (Zaim user {zaimUserId})");
   return c.json({ connected: true, zaimUserId });
@@ -285,15 +284,16 @@ const statusRoute = new Hono<HonoEnv>().get("/zaim/auth/status", async (c) => {
  * KV に保存されたアクセストークンを削除する。
  */
 const tokenRoute = new Hono<HonoEnv>().delete("/zaim/auth/token", async (c) => {
+  const logger = c.var.logger;
   const auth = c.var.oidcAuth;
   if (!auth) {
-    zaimRoutesLogger.warn("Zaim token delete: unauthorized (no OIDC session)");
+    logger.warn("Zaim token delete: unauthorized (no OIDC session)");
     return c.json({ error: "Unauthorized" }, 401);
   }
 
-  zaimRoutesLogger.with({ userSub: auth.sub }).info("Deleting Zaim access token for {userSub}");
+  logger.with({ userSub: auth.sub }).info("Deleting Zaim access token for {userSub}");
   await c.env.ZAIM_KV.delete(`zaim:token:${auth.sub}`);
-  zaimRoutesLogger.with({ userSub: auth.sub }).info("Zaim access token deleted for {userSub}");
+  logger.with({ userSub: auth.sub }).info("Zaim access token deleted for {userSub}");
   return c.json({ ok: true });
 });
 

--- a/apps/server/src/test-fixtures.ts
+++ b/apps/server/src/test-fixtures.ts
@@ -9,6 +9,7 @@ import { type MockedFunction, test, vi } from "vite-plus/test";
 import type { KVNamespace } from "@cloudflare/workers-types";
 import type { OidcAuth } from "@hono/oidc-auth";
 import type { createClient } from "@repo/zaim-api/client";
+import { getLogger } from "@logtape/logtape";
 import { Hono } from "hono";
 import { testClient } from "hono/testing";
 import type { Env, HonoEnv } from "./env.ts";
@@ -108,8 +109,9 @@ export function createTestClient<T extends Hono<HonoEnv, any, any>>(
 ) {
   const base = new Hono<HonoEnv>();
   const testMiddleware = createMiddleware<{
-    Variables: RouteTestContext;
+    Variables: RouteTestContext & { logger: ReturnType<typeof getLogger> };
   }>(async (c, next) => {
+    c.set("logger", getLogger(["quick-zaim", "server"]));
     if ("oidcAuth" in context) c.set("oidcAuth", context.oidcAuth ?? null);
     if ("zaimClient" in context && context.zaimClient) c.set("zaimClient", context.zaimClient);
     if ("zaimUserId" in context && context.zaimUserId) c.set("zaimUserId", context.zaimUserId);

--- a/apps/server/src/zaim-oauth.test.ts
+++ b/apps/server/src/zaim-oauth.test.ts
@@ -6,8 +6,11 @@
  */
 
 import { beforeEach, describe, expect, vi } from "vite-plus/test";
+import { getLogger } from "@logtape/logtape";
 import { fetchZaimAccessToken, fetchZaimRequestToken } from "./zaim-oauth.ts";
 import { oauthTest, parseOAuthHeader } from "./test-fixtures.ts";
+
+const testLogger = getLogger(["quick-zaim", "server"]);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -46,6 +49,7 @@ describe("fetchZaimRequestToken", () => {
       await fetchZaimRequestToken(
         { consumerKey: "key", consumerSecret: "secret" },
         "https://example.com/callback",
+        testLogger,
       );
 
       expect(mockAuthRequestToken).toHaveBeenCalled();
@@ -63,6 +67,7 @@ describe("fetchZaimRequestToken", () => {
       await fetchZaimRequestToken(
         { consumerKey: "mykey", consumerSecret: "mysecret" },
         "https://example.com/callback",
+        testLogger,
       );
 
       const options = mockAuthRequestToken.mock.calls[0][0];
@@ -84,6 +89,7 @@ describe("fetchZaimRequestToken", () => {
       await fetchZaimRequestToken(
         { consumerKey: "key", consumerSecret: "secret" },
         "https://example.com/callback?foo=bar",
+        testLogger,
       );
 
       const options = mockAuthRequestToken.mock.calls[0][0];
@@ -101,6 +107,7 @@ describe("fetchZaimRequestToken", () => {
     const result = await fetchZaimRequestToken(
       { consumerKey: "key", consumerSecret: "secret" },
       "https://example.com/callback",
+      testLogger,
     );
     expect(result).toEqual({ oauthToken: "req_token", oauthTokenSecret: "req_secret" });
   });
@@ -117,6 +124,7 @@ describe("fetchZaimRequestToken", () => {
         fetchZaimRequestToken(
           { consumerKey: "key", consumerSecret: "secret" },
           "https://example.com/callback",
+          testLogger,
         ),
       ).rejects.toThrow("Request token failed [401]");
     },
@@ -134,6 +142,7 @@ describe("fetchZaimRequestToken", () => {
         fetchZaimRequestToken(
           { consumerKey: "key", consumerSecret: "secret" },
           "https://example.com/callback",
+          testLogger,
         ),
       ).rejects.toThrow();
     },
@@ -160,7 +169,7 @@ describe("fetchZaimAccessToken", () => {
         response: new Response(SUCCESS_BODY),
       });
 
-      await fetchZaimAccessToken(REQ_CONFIG, "verifier123");
+      await fetchZaimAccessToken(REQ_CONFIG, "verifier123", testLogger);
 
       expect(mockAuthAccessToken).toHaveBeenCalled();
     },
@@ -174,7 +183,7 @@ describe("fetchZaimAccessToken", () => {
         response: new Response(SUCCESS_BODY),
       });
 
-      await fetchZaimAccessToken(REQ_CONFIG, "myverifier");
+      await fetchZaimAccessToken(REQ_CONFIG, "myverifier", testLogger);
 
       const options = mockAuthAccessToken.mock.calls[0][0];
       const params = parseOAuthHeader(options.headers.Authorization as string);
@@ -191,7 +200,7 @@ describe("fetchZaimAccessToken", () => {
         response: new Response(SUCCESS_BODY),
       });
 
-      const result = await fetchZaimAccessToken(REQ_CONFIG, "verifier");
+      const result = await fetchZaimAccessToken(REQ_CONFIG, "verifier", testLogger);
       expect(result).toEqual({
         oauthToken: "access_token",
         oauthTokenSecret: "access_secret",
@@ -207,7 +216,7 @@ describe("fetchZaimAccessToken", () => {
         response: new Response("Bad Request", { status: 400 }),
       });
 
-      await expect(fetchZaimAccessToken(REQ_CONFIG, "verifier")).rejects.toThrow(
+      await expect(fetchZaimAccessToken(REQ_CONFIG, "verifier", testLogger)).rejects.toThrow(
         "Access token failed [400]",
       );
     },
@@ -221,7 +230,7 @@ describe("fetchZaimAccessToken", () => {
         response: new Response("oauth_token_secret=sec"),
       });
 
-      await expect(fetchZaimAccessToken(REQ_CONFIG, "verifier")).rejects.toThrow();
+      await expect(fetchZaimAccessToken(REQ_CONFIG, "verifier", testLogger)).rejects.toThrow();
     },
   );
 });

--- a/apps/server/src/zaim-oauth.ts
+++ b/apps/server/src/zaim-oauth.ts
@@ -17,7 +17,7 @@ import { createZaimAuthInterceptor } from "@repo/zaim-api/oauth/interceptor";
 import { type OAuth1Config, buildOAuth1AuthorizationHeader } from "@repo/zaim-api/oauth/oauth1";
 import type { AccessTokenResult, RequestTokenResult } from "@repo/zaim-api/oauth/zaim-oauth";
 import * as v from "valibot";
-import { zaimOAuthLogger } from "./logger.ts";
+import type { Logger } from "./loggerMiddleware.ts";
 
 export { buildZaimApiAuthHeader, buildZaimAuthorizeUrl } from "@repo/zaim-api/oauth/zaim-oauth";
 export type { AccessTokenResult, RequestTokenResult } from "@repo/zaim-api/oauth/zaim-oauth";
@@ -45,17 +45,19 @@ const UserVerifySchema = v.object({
  * Zaim から Request Token を取得する
  * @param config      - Consumer Key / Secret
  * @param callbackUrl - OAuth 認可後のコールバック URL
+ * @param logger      - リクエストスコープのロガー
  */
 export async function fetchZaimRequestToken(
   config: OAuth1Config,
   callbackUrl: string,
+  logger: Logger,
 ): Promise<RequestTokenResult> {
   const requestUrl = `${ZAIM_API_BASE}/v2/auth/request`;
   const authHeader = await buildOAuth1AuthorizationHeader("POST", requestUrl, config, {
     oauth_callback: callbackUrl,
   });
 
-  zaimOAuthLogger.with({ url: requestUrl, callbackUrl }).debug("Fetching Zaim request token");
+  logger.with({ url: requestUrl, callbackUrl }).debug("Fetching Zaim request token");
 
   const { data, error, response } = await authRequestToken({
     client: zaimClient,
@@ -63,7 +65,7 @@ export async function fetchZaimRequestToken(
   });
 
   if (error || !data) {
-    zaimOAuthLogger
+    logger
       .with({ status: response?.status, body: error })
       .error("Zaim request token fetch failed [{status}]: {body}");
     throw new Error(`Request token failed [${response?.status}]: ${JSON.stringify(error)}`);
@@ -71,7 +73,7 @@ export async function fetchZaimRequestToken(
 
   const parsed = v.parse(RequestTokenSchema, Object.fromEntries(new URLSearchParams(data)));
 
-  zaimOAuthLogger
+  logger
     .with({ oauthToken: parsed.oauth_token })
     .debug("Zaim request token obtained: {oauthToken}");
 
@@ -86,17 +88,19 @@ export async function fetchZaimRequestToken(
  *
  * @param config        - Consumer Key / Secret + Request Token / Secret
  * @param oauthVerifier - Zaim から受け取った oauth_verifier
+ * @param logger        - リクエストスコープのロガー
  */
 export async function fetchZaimAccessToken(
   config: OAuth1Config,
   oauthVerifier: string,
+  logger: Logger,
 ): Promise<AccessTokenResult> {
   const accessUrl = `${ZAIM_API_BASE}/v2/auth/access`;
   const authHeader = await buildOAuth1AuthorizationHeader("POST", accessUrl, config, {
     oauth_verifier: oauthVerifier,
   });
 
-  zaimOAuthLogger.with({ url: accessUrl }).debug("Fetching Zaim access token");
+  logger.with({ url: accessUrl }).debug("Fetching Zaim access token");
 
   const { data, error, response } = await authAccessToken({
     client: zaimClient,
@@ -104,7 +108,7 @@ export async function fetchZaimAccessToken(
   });
 
   if (error || !data) {
-    zaimOAuthLogger
+    logger
       .with({ status: response?.status, body: error })
       .error("Zaim access token fetch failed [{status}]: {body}");
     throw new Error(`Access token failed [${response?.status}]: ${JSON.stringify(error)}`);
@@ -112,7 +116,7 @@ export async function fetchZaimAccessToken(
 
   const parsed = v.parse(AccessTokenSchema, Object.fromEntries(new URLSearchParams(data)));
 
-  zaimOAuthLogger.debug("Zaim access token obtained");
+  logger.debug("Zaim access token obtained");
 
   return { oauthToken: parsed.oauth_token, oauthTokenSecret: parsed.oauth_token_secret };
 }
@@ -120,17 +124,18 @@ export async function fetchZaimAccessToken(
 /**
  * アクセストークンを使って Zaim のユーザー ID を取得する
  * @param config - Consumer Key / Secret + Access Token / Secret
+ * @param logger - リクエストスコープのロガー
  */
-export async function fetchZaimUserId(config: OAuth1Config): Promise<string> {
+export async function fetchZaimUserId(config: OAuth1Config, logger: Logger): Promise<string> {
   const client = createClient({ baseUrl: ZAIM_API_BASE });
   client.interceptors.request.use(createZaimAuthInterceptor(config));
 
-  zaimOAuthLogger.debug("Fetching Zaim user ID");
+  logger.debug("Fetching Zaim user ID");
 
   const { data, error, response } = await userVerifyUser({ client });
 
   if (error || !data) {
-    zaimOAuthLogger
+    logger
       .with({ status: response?.status, body: error })
       .error("Zaim user verify failed [{status}]: {body}");
     throw new Error(`User verify failed [${response?.status}]: ${JSON.stringify(error)}`);
@@ -139,7 +144,7 @@ export async function fetchZaimUserId(config: OAuth1Config): Promise<string> {
   const parsed = v.parse(UserVerifySchema, data);
   const userId = String(parsed.me.id);
 
-  zaimOAuthLogger.with({ zaimUserId: userId }).debug("Zaim user ID obtained: {zaimUserId}");
+  logger.with({ zaimUserId: userId }).debug("Zaim user ID obtained: {zaimUserId}");
 
   return userId;
 }


### PR DESCRIPTION
## 概要

`logger.ts` にモジュールごとのloggerを追加し続けるパターンを廃止し、Honoミドルウェアでリクエストスコープのloggerを生成・注入するように変更しました。

- リクエスト/レスポンスのログ出力をミドルウェアで一元管理
- `c.var.logger` でリクエストIDを持つloggerにアクセス可能
- 新しいrouteやモジュールを追加する際に `logger.ts` の変更が不要に

## 変更内容

### 追加

- **`loggerMiddleware.ts`** — Honoミドルウェアとして実装
  - `requestId`（UUID）、`method`、`path` をコンテキストに持つloggerを生成
  - `c.var.logger` として注入
  - `<-- GET /path`（debug）と `--> GET /path 200 42ms`（info）をログ出力

### 変更

- **`env.ts`** — `HonoEnv.Variables` に `logger: Logger` を追加。全routeハンドラで型安全に `c.var.logger` が使える

- **`logger.ts`** — `configureSync` の設定のみに簡略化。`authLogger`、`zaimRoutesLogger` などの named export をすべて削除

- **`index.ts`** — `@logtape/hono` の `honoLogger` を `loggerMiddleware` に置き換え

- **各routeファイル** — `import { xxxLogger }` → `const logger = c.var.logger`

- **`zaim-oauth.ts`** — `fetchZaimRequestToken`、`fetchZaimAccessToken`、`fetchZaimUserId` にlogger引数を追加し、リクエストのトレーシングを維持

- **`test-fixtures.ts`** / **`zaim-oauth.test.ts`** — テスト環境でもloggerを注入・渡すよう更新

## ログの流れ

```
リクエスト受信
→ loggerMiddleware: requestId生成、c.var.logger に注入
  → <-- GET /api/zaim/payment（debug）
  → routeハンドラ: c.var.logger.with({ userId }).info("...")
    → helper関数: logger引数で受け取り .debug("...")
  → --> GET /api/zaim/payment 201 42ms（info）
```

すべてのログに同じ `requestId` が含まれるため、リクエスト単位でのトレーシングが可能です。

## テスト

- `vp check` パス（型・lint・フォーマットエラーなし）
- `vp test` パス（60件すべて通過）

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGYJQBndc9tthhMJ7w4mgo)_